### PR TITLE
Ensure publish is called once per L1 transaction

### DIFF
--- a/src/protocol/DataFeed.sol
+++ b/src/protocol/DataFeed.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.28;
 import {IDataFeed} from "./IDataFeed.sol";
 
 contract DataFeed is IDataFeed {
-    // keccak256(abi.encode(uint256(keccak256("minimal-rollup.storage.TransactionGuard")) - 1)) & ~bytes32(uint256(0xff))
+    // keccak256(abi.encode(uint256(keccak256("minimal-rollup.storage.TransactionGuard")) - 1)) &
+    // ~bytes32(uint256(0xff))
     bytes32 private constant TRANSACTION_GUARD = 0x99b77697c9b37eb2c48d30bc6afcf1840fbb1ccae9217c44df166cd11b25cc00;
 
     /// @dev a list of hashes identifying all data accompanying calls to the `publish` function.


### PR DESCRIPTION
As Daniel noted [here](https://github.com/OpenZeppelin/minimal-rollup/pull/1#issue-2852470198),
an attacker can reuse the same blobs to spam the prover.

This uses transient storage to ensure publish is only called once per transaction
