### PR TITLE
Add blockNumber to publication

### DIFF
--- a/src/protocol/DataFeed.sol
+++ b/src/protocol/DataFeed.sol
@@ -37,8 +37,14 @@ contract DataFeed is IDataFeed {
         require(numBlobs > 0, "no data to publish");
 
         uint256 nQueries = queries.length;
-        Publication memory publication =
-            Publication(msg.sender, block.timestamp, new bytes32[](numBlobs), queries, new bytes[](nQueries));
+        Publication memory publication = Publication({
+            publisher: msg.sender,
+            timestamp: block.timestamp,
+            blockNumber: block.number,
+            blobHashes: new bytes32[](numBlobs),
+            queries: queries,
+            metadata: new bytes[](nQueries)
+        });
 
         for (uint256 i; i < numBlobs; ++i) {
             publication.blobHashes[i] = blobhash(i);

--- a/src/protocol/IDataFeed.sol
+++ b/src/protocol/IDataFeed.sol
@@ -11,6 +11,7 @@ interface IDataFeed {
     struct Publication {
         address publisher;
         uint256 timestamp;
+        uint256 blockNumber;
         bytes32[] blobHashes;
         MetadataQuery[] queries;
         bytes[] metadata;


### PR DESCRIPTION
To facilitate snapshot-based peer-to-peer (P2P) state synchronization, it’s essential to include publication's `blockNumber` in the Layer 2 block header. This inclusion enables clients, post-synchronization, to identify the specific L1 block from which they should sequentially process publications.