### PR TITLE
[DRAFT] allow each rollup to define when to sync direct publications

### DIFF
--- a/src/protocol/DataFeed.sol
+++ b/src/protocol/DataFeed.sol
@@ -36,7 +36,6 @@ contract DataFeed is IDataFeed {
         require(numBlobs > 0, "no data to publish");
 
         uint256 id = publicationHashes.length;
-        uint256 directId = directPublicationHashes.length;
         Publication memory publication = Publication({
             id: id,
             prevHash: publicationHashes[id - 1],
@@ -46,8 +45,7 @@ contract DataFeed is IDataFeed {
             blobHashes: new bytes32[](numBlobs),
             queries: queries,
             metadata: new bytes[](queries.length),
-            directPublicationId: directId,
-            directPublicationHash: directPublicationHashes[directId - 1]
+            directPublicationHashes: new bytes32[](queries.length)
         });
 
         for (uint256 i; i < numBlobs; ++i) {
@@ -93,6 +91,7 @@ contract DataFeed is IDataFeed {
             metadata[i] = IMetadataProvider(queries[i].provider).getMetadata{value: queries[i].value}(
                 msg.sender, queries[i].input
             );
+            directPublicationHashes[i] = IMetadataProvider(queries[i].provider).getDirectPublicationHash();
             totalValue += queries[i].value;
         }
         require(msg.value == totalValue, "Incorrect ETH passed with publication");

--- a/src/protocol/IDataFeed.sol
+++ b/src/protocol/IDataFeed.sol
@@ -17,8 +17,7 @@ interface IDataFeed {
         bytes32[] blobHashes;
         MetadataQuery[] queries;
         bytes[] metadata;
-        uint256 directPublicationId;
-        bytes32 directPublicationHash;
+        bytes32[] directPublicationHashes;
     }
 
     struct DirectPublication {

--- a/src/protocol/IMetadataProvider.sol
+++ b/src/protocol/IMetadataProvider.sol
@@ -1,10 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IDataFeed} from "./IDataFeed.sol";
+
 interface IMetadataProvider {
     /// @notice Returns L1 metadata associated with a publication
     /// @param publisher The address of the publisher
     /// @param input The input to the metadata provider
     /// @return metadata The metadata
     function getMetadata(address publisher, bytes memory input) external payable returns (bytes memory metadata);
+
+    /// @notice Returns the hash of the latest available direct publication
+    /// @return directPublicationHash The hash of the latest direct publication
+    function getDirectPublicationHash() external view returns (bytes32);
+
+    /// @notice Updates the hash of the latest available direct publication for the rollup
+    /// @param publication The direct publication
+    /// @param idx The index of the direct publication in the `DataFeed` contract
+    function setLastDirectPublicationHash(IDataFeed.DirectPublication calldata publication, uint256 idx) external;
 }

--- a/src/protocol/taiko_alethia/TaikoMetadataProvider.sol
+++ b/src/protocol/taiko_alethia/TaikoMetadataProvider.sol
@@ -1,16 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IDataFeed} from "../IDataFeed.sol";
 import {IMetadataProvider} from "../IMetadataProvider.sol";
 import {ILookahead} from "./ILookahead.sol";
 
 contract TaikoMetadataProvider is IMetadataProvider {
     uint256 public immutable maxAnchorBlockIdOffset;
     address public immutable lookahead;
+    IDataFeed public immutable dataFeed;
 
-    constructor(uint256 _maxAnchorBlockIdOffset, address _lookahead) {
+    /// @dev This is the last direct publication hash that the rollup has "seen" and will force
+    /// the sequencer to include as part of the next publication.
+    bytes32 private lastDirectPublicationHash;
+
+    constructor(uint256 _maxAnchorBlockIdOffset, address _lookahead, address _dataFeed) {
         maxAnchorBlockIdOffset = _maxAnchorBlockIdOffset;
         lookahead = _lookahead;
+        dataFeed = IDataFeed(_dataFeed);
     }
 
     /// @inheritdoc IMetadataProvider
@@ -27,5 +34,20 @@ contract TaikoMetadataProvider is IMetadataProvider {
         bytes32 anchorBlockhash = blockhash(anchorBlockId);
         require(anchorBlockhash != 0, "blockhash not found");
         return abi.encode(anchorBlockhash);
+    }
+
+    /// @inheritdoc IMetadataProvider
+    function setLastDirectPublicationHash(IDataFeed.DirectPublication calldata publication, uint256 idx) external {
+        bytes32 dataFeedHash = dataFeed.getDirectPublicationHash(idx);
+        bytes32 publicationHash = keccak256(abi.encode(publication));
+
+        require(dataFeedHash == publicationHash, "dataFeedHash does not match publicationHash");
+
+        lastDirectPublicationHash = publicationHash;
+    }
+
+    /// @inheritdoc IMetadataProvider
+    function getDirectPublicationHash() external view returns (bytes32) {
+        return lastDirectPublicationHash;
     }
 }


### PR DESCRIPTION
This is a proposal for how we can allow each rollup(via its provider, which we should rename to hooks or similar) what direct publication they want to reference. This avoids enforcing "real time" CR inclusion for rollups, and gives them the flexibility to define rules about when a direct publication is linked to an actual publication. 
This will usually be time delays, similar to a delayed inbox, but in theory a rollup can define more complex rules if they want.

This is how a user would force a tx:
1. They(or someone on their behalf) calls `directPublish` with bundles for one or multiple rollups
2. They(or someone on their behalf) calls `setLastDirectPublicationHash` on the provider to update the last direct publication that the rollup "sees". Here each provider can enforce a delay, or whatever rule they want.
3. The direct publication is linked to the next publication when the metadata is retrieved.

I'm not sure if this is the best approach, or if it is just better to keep separate queues per rollup. But this seemed simple and elegant enough that it made sense to me :)

Once we agree with an approach I can go ahead and rename the provider to Hooks or something similar.