### PR TITLE
Calldata Support

### DIFF
--- a/src/protocol/DataFeed.sol
+++ b/src/protocol/DataFeed.sol
@@ -36,22 +36,21 @@ contract DataFeed is IDataFeed {
         uint256 nQueries = queries.length;
         uint256 id = publicationHashes.length;
 
-        bytes32[] memory blobHashes = new bytes32[](numBlobs);
-        for (uint256 i; i < numBlobs; ++i) {
-            blobHashes[i] = blobhash(i);
-        }
-        bytes32 dataHash = keccak256(abi.encode(data, blobHashes));
-
         Publication memory publication = Publication({
             id: id,
             prevHash: publicationHashes[id - 1],
             publisher: msg.sender,
             timestamp: block.timestamp,
             blockNumber: block.number,
-            dataHash: dataHash,
+            blobHashes: new bytes32[](numBlobs),
+            data: data,
             queries: queries,
             metadata: new bytes[](nQueries)
         });
+
+        for (uint256 i; i < numBlobs; ++i) {
+            publication.blobHashes[i] = blobhash(i);
+        }
 
         uint256 totalValue;
         for (uint256 i; i < nQueries; ++i) {

--- a/src/protocol/DataFeed.sol
+++ b/src/protocol/DataFeed.sol
@@ -33,8 +33,6 @@ contract DataFeed is IDataFeed {
         payable
         onlyStandaloneTx
     {
-        require(numBlobs > 0, "no data to publish");
-
         uint256 nQueries = queries.length;
         uint256 id = publicationHashes.length;
 

--- a/src/protocol/DataFeed.sol
+++ b/src/protocol/DataFeed.sol
@@ -27,13 +27,7 @@ contract DataFeed is IDataFeed {
         publicationHashes.push(0);
     }
 
-    /// @notice Publish arbitrary data in blobs for data availability.
-    /// @param numBlobs the number of blobs accompanying this function call.
-    /// @param queries the calls required to retrieve L1 metadata hashes associated with this publication.
-    /// @dev there can be multiple queries because a single publication might represent multiple rollups,
-    /// each with their own L1 metadata requirements
-    /// @dev append a hash representing all blobs and L1 metadata to `publicationHashes`.
-    /// The number of blobs is not validated. Additional blobs are ignored. Empty blobs have a hash of zero.
+    /// @inheritdoc IDataFeed
     function publish(uint256 numBlobs, MetadataQuery[] calldata queries) external payable onlyStandaloneTx {
         require(numBlobs > 0, "no data to publish");
 
@@ -69,9 +63,7 @@ contract DataFeed is IDataFeed {
         emit Published(pubHash, publication);
     }
 
-    /// @notice retrieve a hash representing a previous publication
-    /// @param idx the index of the publication hash
-    /// @return _ the corresponding publication hash
+    /// @inheritdoc IDataFeed
     function getPublicationHash(uint256 idx) external view returns (bytes32) {
         return publicationHashes[idx];
     }

--- a/src/protocol/DataFeed.sol
+++ b/src/protocol/DataFeed.sol
@@ -55,7 +55,6 @@ contract DataFeed is IDataFeed {
             metadata: new bytes[](nQueries)
         });
 
-        
         uint256 totalValue;
         for (uint256 i; i < nQueries; ++i) {
             publication.metadata[i] = IMetadataProvider(queries[i].provider).getMetadata{value: queries[i].value}(

--- a/src/protocol/IDataFeed.sol
+++ b/src/protocol/IDataFeed.sol
@@ -24,11 +24,17 @@ interface IDataFeed {
     /// @param publication the Publication struct describing the preimages to pubHash
     event Published(bytes32 indexed pubHash, Publication publication);
 
-    /// @notice Publish data as blobs for data availability
+    /// @notice Publish arbitrary data in blobs for data availability.
     /// @param numBlobs the number of blobs accompanying this function call.
     /// @param queries the calls required to retrieve L1 metadata hashes associated with this publication.
+    /// @dev there can be multiple queries because a single publication might represent multiple rollups,
+    /// each with their own L1 metadata requirements
+    /// @dev append a hash representing all blobs and L1 metadata to `publicationHashes`.
+    /// The number of blobs is not validated. Additional blobs are ignored. Empty blobs have a hash of zero.
     function publish(uint256 numBlobs, MetadataQuery[] calldata queries) external payable;
 
-    /// @notice Returns the hash of the publication at the given index
+    /// @notice retrieve a hash representing a previous publication
+    /// @param idx the index of the publication hash
+    /// @return _ the corresponding publication hash
     function getPublicationHash(uint256 idx) external view returns (bytes32);
 }

--- a/src/protocol/IDataFeed.sol
+++ b/src/protocol/IDataFeed.sol
@@ -14,7 +14,7 @@ interface IDataFeed {
         address publisher;
         uint256 timestamp;
         uint256 blockNumber;
-        bytes32[] blobHashes;
+        bytes32 dataHash;
         MetadataQuery[] queries;
         bytes[] metadata;
     }
@@ -24,14 +24,15 @@ interface IDataFeed {
     /// @param publication the Publication struct describing the preimages to pubHash
     event Published(bytes32 indexed pubHash, Publication publication);
 
-    /// @notice Publish arbitrary data in blobs for data availability.
+    /// @notice Publish arbitrary data for data availability.
     /// @param numBlobs the number of blobs accompanying this function call.
+    /// @param data the data to publish in calldata.
     /// @param queries the calls required to retrieve L1 metadata hashes associated with this publication.
     /// @dev there can be multiple queries because a single publication might represent multiple rollups,
     /// each with their own L1 metadata requirements
     /// @dev append a hash representing all blobs and L1 metadata to `publicationHashes`.
     /// The number of blobs is not validated. Additional blobs are ignored. Empty blobs have a hash of zero.
-    function publish(uint256 numBlobs, MetadataQuery[] calldata queries) external payable;
+    function publish(uint256 numBlobs, bytes calldata data, MetadataQuery[] calldata queries) external payable;
 
     /// @notice retrieve a hash representing a previous publication
     /// @param idx the index of the publication hash

--- a/src/protocol/IDataFeed.sol
+++ b/src/protocol/IDataFeed.sol
@@ -14,7 +14,8 @@ interface IDataFeed {
         address publisher;
         uint256 timestamp;
         uint256 blockNumber;
-        bytes32 dataHash;
+        bytes32[] blobHashes;
+        bytes data;
         MetadataQuery[] queries;
         bytes[] metadata;
     }

--- a/test/DataFeed.t.sol
+++ b/test/DataFeed.t.sol
@@ -15,11 +15,11 @@ contract DataFeedTest is Test {
     function testRevert_NoBlobs() public {
         vm.expectRevert();
         IDataFeed.MetadataQuery[] memory queries = new IDataFeed.MetadataQuery[](0);
-        feed.publish(0, queries);
+        feed.publish(0, "", queries);
     }
 
     function test_EmptyBlobDoesNotRevert() public {
         IDataFeed.MetadataQuery[] memory queries = new IDataFeed.MetadataQuery[](0);
-        feed.publish(1, queries);
+        feed.publish(1, "", queries);
     }
 }

--- a/test/DataFeed.t.sol
+++ b/test/DataFeed.t.sol
@@ -12,8 +12,7 @@ contract DataFeedTest is Test {
         feed = new DataFeed();
     }
 
-    function testRevert_NoBlobs() public {
-        vm.expectRevert();
+    function test_NoBlobsDoesNotRevert() public {
         IDataFeed.MetadataQuery[] memory queries = new IDataFeed.MetadataQuery[](0);
         feed.publish(0, "", queries);
     }


### PR DESCRIPTION
Include calldata in the Publication.

I also replaced the `blobHashes` field with a single data hash that covers all blobs and calldata.

Also minor cleanup: use inheritdoc for the NatSpec comments