### PR TITLE
Remove blob hashes from publication

### DIFF
--- a/src/protocol/DataFeed.sol
+++ b/src/protocol/DataFeed.sol
@@ -14,12 +14,10 @@ contract DataFeed is IDataFeed {
     }
 
     /// @inheritdoc IDataFeed
-    function publish(
-        uint256 numBlobs,
-        bytes calldata data,
-        HookQuery[] calldata preHookQueries,
-        HookQuery[] calldata postHookQueries
-    ) external payable {
+    function publish(bytes calldata data, HookQuery[] calldata preHookQueries, HookQuery[] calldata postHookQueries)
+        external
+        payable
+    {
         uint256 nHooks = preHookQueries.length;
         uint256 totalValue;
         bytes[] memory auxData = new bytes[](nHooks);
@@ -37,16 +35,11 @@ contract DataFeed is IDataFeed {
             publisher: msg.sender,
             timestamp: block.timestamp,
             blockNumber: block.number,
-            blobHashes: new bytes32[](numBlobs),
             data: data,
             preHookQueries: preHookQueries,
             postHookQueries: postHookQueries,
             auxData: auxData
         });
-
-        for (uint256 i; i < numBlobs; ++i) {
-            publication.blobHashes[i] = blobhash(i);
-        }
 
         bytes32 pubHash = keccak256(abi.encode(publication));
         publicationHashes.push(pubHash);

--- a/src/protocol/IDataFeed.sol
+++ b/src/protocol/IDataFeed.sol
@@ -14,7 +14,6 @@ interface IDataFeed {
         address publisher;
         uint256 timestamp;
         uint256 blockNumber;
-        bytes32[] blobHashes;
         bytes data;
         HookQuery[] preHookQueries;
         HookQuery[] postHookQueries;
@@ -28,18 +27,14 @@ interface IDataFeed {
 
     /// @notice Publish arbitrary data for data availability.
     /// @param data the data to publish in calldata.
-    /// @param numBlobs the number of blobs accompanying this function call.
     /// @param preHookQueries arbitrary calls to retrieve auxiliary data that should be contained in the publication
     /// @param postHookQueries arbitrary calls to be executed after the publication
     /// @dev there can be multiple pre hooks and post hooks because a single publication might represent multiple
     /// rollups,
     /// each with their own requirements
-    function publish(
-        uint256 numBlobs,
-        bytes calldata data,
-        HookQuery[] calldata preHookQueries,
-        HookQuery[] calldata postHookQueries
-    ) external payable;
+    function publish(bytes calldata data, HookQuery[] calldata preHookQueries, HookQuery[] calldata postHookQueries)
+        external
+        payable;
 
     /// @notice retrieve a hash representing a previous publication
     /// @param idx the index of the publication hash

--- a/test/DataFeed.t.sol
+++ b/test/DataFeed.t.sol
@@ -12,13 +12,8 @@ contract DataFeedTest is Test {
         feed = new DataFeed();
     }
 
-    function test_NoBlobsDoesNotRevert() public {
+    function test_PublishDoesNotRevert() public {
         IDataFeed.HookQuery[] memory queries = new IDataFeed.HookQuery[](0);
-        feed.publish(0, "", queries, queries);
-    }
-
-    function test_EmptyBlobDoesNotRevert() public {
-        IDataFeed.HookQuery[] memory queries = new IDataFeed.HookQuery[](0);
-        feed.publish(1, "", queries, queries);
+        feed.publish("", queries, queries);
     }
 }


### PR DESCRIPTION
The PublicationHook can check the hashes if desired, and/or return
them in the auxData. The number of blobs can also be passed in the
data field.

The intention is to explicitly remove any data availability requirements.
This enables the possibility for publication hooks to add non-validated
publications to the queue
