### PR TITLE
Add attributesHash to Publication

### DIFF
--- a/src/protocol/DataFeed.sol
+++ b/src/protocol/DataFeed.sol
@@ -14,21 +14,23 @@ contract DataFeed is IDataFeed {
 
     /// @inheritdoc IDataFeed
     function publish(bytes[] calldata attributes) external override returns (PublicationHeader memory header) {
+        uint256 nAttributes = attributes.length;
+        bytes32[] memory attributeHashes = new bytes32[](nAttributes);
+        for (uint256 i; i < nAttributes; ++i) {
+            attributeHashes[i] = keccak256(attributes[i]);
+        }
+
         uint256 id = publicationHashes.length;
         header = PublicationHeader({
             id: id,
             prevHash: publicationHashes[id - 1],
             publisher: msg.sender,
             timestamp: block.timestamp,
-            blockNumber: block.number
+            blockNumber: block.number,
+            attributesHash: keccak256(abi.encode(attributeHashes))
         });
 
-        uint256 nAttributes = attributes.length;
-        bytes32[] memory attributeHashes = new bytes32[](nAttributes);
-        for (uint256 i; i < nAttributes; ++i) {
-            attributeHashes[i] = keccak256(attributes[i]);
-        }
-        bytes32 pubHash = keccak256(abi.encode(header, keccak256(abi.encode(attributeHashes))));
+        bytes32 pubHash = keccak256(abi.encode(header));
         publicationHashes.push(pubHash);
 
         emit Published(pubHash, header, attributes);

--- a/src/protocol/IDataFeed.sol
+++ b/src/protocol/IDataFeed.sol
@@ -8,6 +8,7 @@ interface IDataFeed {
         address publisher;
         uint256 timestamp;
         uint256 blockNumber;
+        bytes32 attributesHash;
     }
 
     /// @notice Emitted when a new publication is created


### PR DESCRIPTION
This allows for publication to be verified without all attribute hashes.