### PR TITLE
Add BlobSlice to IBlobRefRegistry.sol

### DIFF
--- a/src/blobs/IBlobRefRegistry.sol
+++ b/src/blobs/IBlobRefRegistry.sol
@@ -12,6 +12,16 @@ interface IBlobRefRegistry {
         bytes32[] blobhashes;
     }
 
+    /// @dev Struct representing a slice of data from a BlobRef
+    /// @param blobRefHash The keccak256 hash of the encoded BlobRef
+    /// @param startIndex The start index of the blob slice`
+    /// @param endIndex The end index of the blob slice
+    struct BlobSlice {
+        bytes32 blobRefHash;
+        uint32 startIndex;
+        uint32 endIndex;
+    }
+
     /// @notice Emitted when a blob ref hash is registered
     /// @param refHash The keccak256 hash of the encoded blob ref
     /// @param ref The blob ref

--- a/src/blobs/IBlobRefRegistry.sol
+++ b/src/blobs/IBlobRefRegistry.sol
@@ -14,8 +14,8 @@ interface IBlobRefRegistry {
 
     /// @dev Struct representing a slice of data from a BlobRef
     /// @param blobRefHash The keccak256 hash of the encoded BlobRef
-    /// @param startIndex The start index of the blob slice`
-    /// @param endIndex The end index of the blob slice
+    /// @param startIndex The start index of the blob slice
+    /// @param size The number of bytes in the slice
     struct BlobSlice {
         bytes32 blobRefHash;
         uint32 startIndex;

--- a/src/blobs/IBlobRefRegistry.sol
+++ b/src/blobs/IBlobRefRegistry.sol
@@ -19,7 +19,7 @@ interface IBlobRefRegistry {
     struct BlobSlice {
         bytes32 blobRefHash;
         uint32 startIndex;
-        uint32 endIndex;
+        uint32 size;
     }
 
     /// @notice Emitted when a blob ref hash is registered


### PR DESCRIPTION
The `BlobSlice` struct is likely to be used by dapps that share blobs. Adding it here prevents each apps from having to redefine it individually.