### PR TITLE
Refactor Signal Service for generalised Message Passing

### DIFF
--- a/src/libs/LibValueTicket.sol
+++ b/src/libs/LibValueTicket.sol
@@ -47,26 +47,19 @@ library LibValueTicket {
         bytes[] memory storageProof
     ) internal view returns (bool verified, bytes32 _id) {
         _id = id(ticket);
-        if (accountProof.length == 0) {
-            ISignalService(signalService).verifySignal(
-                address(this), root, ticket.chainId, _id, accountProof, storageProof
-            );
-            // true because call will revert otherwise
-            return (true, _id);
-        }
-        (verified,) = address(this).verifySignal(root, ticket.chainId, _id, accountProof, storageProof);
-        return (verified, _id);
+        ISignalService(signalService).verifySignal(address(this), root, ticket.chainId, _id, accountProof, storageProof);
+        // true because call will revert otherwise
+        return (true, _id);
     }
 
     /// @dev Creates a ticket with `msg.value` ETH for the receiver (`to`) to claim on the `destinationChainId`.
-    function createTicket(uint64 destinationChainId, address from, address to, uint256 value)
+    function createTicket(uint64 destinationChainId, address from, address to, uint256 value, address signalService)
         internal
-        returns (ValueTicket memory ticket)
+        returns (ValueTicket memory)
     {
         ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
         bytes32 _id = id(ticket);
-        _id.signal();
-        return ticket;
+        ISignalService(signalService).sendSignal(_id);
     }
 
     /// @dev Creates a ticket with `msg.value` ETH for the receiver (`to`) to claim on the `destinationChainId`.
@@ -78,8 +71,7 @@ library LibValueTicket {
     {
         ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
         bytes32 _id = id(ticket);
-        ISignalService(signalService).sendSignal(_id);
-        return ticket;
+        ISignalService(signalService).sendFastSignal(_id);
     }
 
     /// @dev Reverts if a ticket was not created by `from` with `nonce` on `chainId`. See `verifyTicket`.

--- a/src/libs/LibValueTicket.sol
+++ b/src/libs/LibValueTicket.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {LibSignal} from "../libs/LibSignal.sol";
 import {ISignalService} from "../protocol/ISignalService.sol";
 import {SlotDerivation} from "@openzeppelin/contracts/utils/SlotDerivation.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
@@ -14,7 +13,6 @@ import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 library LibValueTicket {
     using SafeCast for uint256;
     using StorageSlot for bytes32;
-    using LibSignal for *;
     using SlotDerivation for *;
 
     struct ValueTicket {

--- a/src/libs/LibValueTicket.sol
+++ b/src/libs/LibValueTicket.sol
@@ -61,10 +61,11 @@ library LibValueTicket {
     /// @dev Creates a ticket with `msg.value` ETH for the receiver (`to`) to claim on the `destinationChainId`.
     function createTicket(uint64 destinationChainId, address from, address to, uint256 value)
         internal
-        returns (ValueTicket memory)
+        returns (ValueTicket memory ticket)
     {
-        ValueTicket memory ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
-        id(ticket).signal();
+        ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
+        bytes32 _id = id(ticket);
+        _id.signal();
         return ticket;
     }
 
@@ -75,8 +76,9 @@ library LibValueTicket {
         internal
         returns (ValueTicket memory)
     {
-        ValueTicket memory ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
-        ISignalService(signalService).sendSignal(id(ticket));
+        ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
+        bytes32 _id = id(ticket);
+        ISignalService(signalService).sendSignal(_id);
         return ticket;
     }
 

--- a/src/libs/LibValueTicket.sol
+++ b/src/libs/LibValueTicket.sol
@@ -55,7 +55,7 @@ library LibValueTicket {
     /// @dev Creates a ticket with `msg.value` ETH for the receiver (`to`) to claim on the `destinationChainId`.
     function createTicket(uint64 destinationChainId, address from, address to, uint256 value, address signalService)
         internal
-        returns (ValueTicket memory)
+        returns (ValueTicket memory ticket)
     {
         ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
         bytes32 _id = id(ticket);
@@ -67,7 +67,7 @@ library LibValueTicket {
     /// @dev This is only for L1->L2 bridging
     function createFastTicket(uint64 destinationChainId, address from, address to, uint256 value, address signalService)
         internal
-        returns (ValueTicket memory)
+        returns (ValueTicket memory ticket)
     {
         ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
         bytes32 _id = id(ticket);

--- a/src/protocol/ETHBridge.sol
+++ b/src/protocol/ETHBridge.sol
@@ -49,7 +49,7 @@ contract ETHBridge is IETHBridge {
 
     /// @inheritdoc IETHBridge
     function createFastTicket(uint64 chainId, address to) external payable virtual {
-        emit ETHTicket(LibValueTicket.createFastTicket(chainId, msg.sender, to, msg.value, signalService));
+        emit FastETHTicket(LibValueTicket.createFastTicket(chainId, msg.sender, to, msg.value, signalService));
     }
 
     /// @inheritdoc IETHBridge

--- a/src/protocol/ETHBridge.sol
+++ b/src/protocol/ETHBridge.sol
@@ -39,7 +39,7 @@ contract ETHBridge is IETHBridge {
         bytes[] memory accountProof,
         bytes[] memory proof
     ) public view virtual returns (bool verified, bytes32 id) {
-        return ticket.verifyTicket(root, accountProof, proof);
+        return ticket.verifyTicket(signalService, root, accountProof, proof);
     }
 
     /// @inheritdoc IETHBridge
@@ -59,7 +59,7 @@ contract ETHBridge is IETHBridge {
         bytes[] memory accountProof,
         bytes[] memory proof
     ) external virtual {
-        bytes32 id_ = ticket.checkTicket(root, accountProof, proof);
+        bytes32 id_ = ticket.checkTicket(signalService, root, accountProof, proof);
         require(!claimed(id_), AlreadyClaimed());
         _claimed[id_] = true;
         _sendETH(ticket.to, ticket.value);

--- a/src/protocol/ETHBridge.sol
+++ b/src/protocol/ETHBridge.sol
@@ -5,6 +5,7 @@ import {LibTrieProof} from "../libs/LibTrieProof.sol";
 
 import {LibValueTicket} from "../libs/LibValueTicket.sol";
 import {IETHBridge} from "./IETHBridge.sol";
+import {ISignalService} from "./ISignalService.sol";
 
 /// @dev Bridge implementation to send native ETH to other chains using storage proofs.
 ///
@@ -13,7 +14,13 @@ import {IETHBridge} from "./IETHBridge.sol";
 contract ETHBridge is IETHBridge {
     using LibValueTicket for LibValueTicket.ValueTicket;
 
+    address public immutable signalService;
+
     mapping(bytes32 id => bool) _claimed;
+
+    constructor(address _signalService) {
+        signalService = _signalService;
+    }
 
     /// @inheritdoc IETHBridge
     function claimed(bytes32 id) public view virtual returns (bool) {
@@ -38,6 +45,11 @@ contract ETHBridge is IETHBridge {
     /// @inheritdoc IETHBridge
     function createTicket(uint64 chainId, address to) external payable virtual {
         emit ETHTicket(LibValueTicket.createTicket(chainId, msg.sender, to, msg.value));
+    }
+
+    /// @inheritdoc IETHBridge
+    function createFastTicket(uint64 chainId, address to) external payable virtual {
+        emit ETHTicket(LibValueTicket.createFastTicket(chainId, msg.sender, to, msg.value, signalService));
     }
 
     /// @inheritdoc IETHBridge

--- a/src/protocol/ETHBridge.sol
+++ b/src/protocol/ETHBridge.sol
@@ -44,7 +44,7 @@ contract ETHBridge is IETHBridge {
 
     /// @inheritdoc IETHBridge
     function createTicket(uint64 chainId, address to) external payable virtual {
-        emit ETHTicket(LibValueTicket.createTicket(chainId, msg.sender, to, msg.value));
+        emit ETHTicket(LibValueTicket.createTicket(chainId, msg.sender, to, msg.value, signalService));
     }
 
     /// @inheritdoc IETHBridge

--- a/src/protocol/IETHBridge.sol
+++ b/src/protocol/IETHBridge.sol
@@ -13,6 +13,10 @@ interface IETHBridge {
     /// @dev Sender (`from`) sent `value` with `nonce` to the receiver (`to`). Claimable on `chainId`.
     event ETHTicket(LibValueTicket.ValueTicket ticket);
 
+    /// @dev Sender (`from`) sent `value` with `nonce` to the receiver (`to`). Claimable on `chainId` within the same
+    /// slot.
+    event FastETHTicket(LibValueTicket.ValueTicket ticket);
+
     /// @dev A ticket was claimed.
     event ETHTicketClaimed(LibValueTicket.ValueTicket ticket);
 

--- a/src/protocol/IETHBridge.sol
+++ b/src/protocol/IETHBridge.sol
@@ -41,6 +41,10 @@ interface IETHBridge {
     /// @dev Creates a ticket with `msg.value` ETH for the receiver (`to`) to claim on the `chainId`.
     function createTicket(uint64 chainId, address to) external payable;
 
+    /// @dev Creates a ticket that is redeamable within the same slot.
+    /// @dev This is only for L1->L2 bridging
+    function createFastTicket(uint64 chainId, address to) external payable;
+
     /// @dev Claims a ticket created on `chainId` by the sender (`from`) with `nonce`. The `value` ETH claimed  is
     /// sent to the receiver (`to`) after verifying the proofs. See `verifyTicket`.
     function claimTicket(

--- a/src/protocol/ISignalService.sol
+++ b/src/protocol/ISignalService.sol
@@ -8,8 +8,11 @@ interface ISignalService {
     error CallerNotAuthorised();
 
     event SignalsReceived(bytes32[] signalSlots);
+    event FastSignalSent(bytes32 signal);
+    event SignalSent(bytes32 signal);
 
     function sendSignal(bytes32 value) external returns (bytes32);
+    function sendFastSignal(bytes32 value) external returns (bytes32);
 
     function receiveSignals(bytes32[] calldata signalSlots) external;
 

--- a/src/protocol/SignalService.sol
+++ b/src/protocol/SignalService.sol
@@ -26,8 +26,15 @@ contract SignalService is ISignalService {
     }
 
     /// @dev Only required to be called on L1
-    function sendSignal(bytes32 value) external returns (bytes32) {
-        return value.signal();
+    function sendSignal(bytes32 value) external returns (bytes32 signal) {
+        signal = value.signal();
+        emit SignalSent(signal);
+    }
+
+    /// @dev Only required to be called on L1
+    function sendFastSignal(bytes32 value) external returns (bytes32 signal) {
+        signal = value.signal();
+        emit FastSignalSent(signal);
     }
 
     /// @dev Only required to be called on L2

--- a/src/protocol/SignalService.sol
+++ b/src/protocol/SignalService.sol
@@ -7,7 +7,6 @@ import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 
 /// @title SignalService
 /// @notice A minimal implementation of a signal service using LibSignal.
-/// @dev This is for same slot signal passing.
 contract SignalService is ISignalService {
     using LibSignal for bytes32;
     using StorageSlot for bytes32;

--- a/src/protocol/SignalService.sol
+++ b/src/protocol/SignalService.sol
@@ -7,6 +7,7 @@ import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 
 /// @title SignalService
 /// @notice A minimal implementation of a signal service using LibSignal.
+/// @dev This is for same slot signal passing.
 contract SignalService is ISignalService {
     using LibSignal for bytes32;
     using StorageSlot for bytes32;


### PR DESCRIPTION
Updated:

- merged https://github.com/OpenZeppelin/minimal-rollup/pull/63 changing the signal service to handle both F and S signals.

- Added `sendFastSignal` to signal service (not sure if this is neccessary)
- Bridge no longer handles signalling - all gets delegated to signal service 

--- **Thoughts** ---

Things that are still unclear / open to discussion.

- A lot of `verifyX` functions in the signalling pathways rely on a given state L1 root, however its never verified that this is from a trusted source / the actual L1 state root. I feel like this is an issue. (Also unsure how the commitment syncer fits in all this --> doesn't seem its being used for any signalling pathways)

- Perhaps we could think about unifying some libraries currently we have a lot of layers of indirection e.g the claim ticket flow is as follows: claimTicket --> lib.checkTicket --> lib.verifyTicket --> signal.verifySignal. No strong opinions here however from a DevEX perspective it was harder to implement additional functionality / follow the flow.
