### PR TITLE
Make signal service handle both 'fast' and 'slow' signals

### DIFF
--- a/src/libs/LibValueTicket.sol
+++ b/src/libs/LibValueTicket.sol
@@ -47,26 +47,19 @@ library LibValueTicket {
         bytes[] memory storageProof
     ) internal view returns (bool verified, bytes32 _id) {
         _id = id(ticket);
-        if (accountProof.length == 0) {
-            ISignalService(signalService).verifySignal(
-                address(this), root, ticket.chainId, _id, accountProof, storageProof
-            );
-            // true because call will revert otherwise
-            return (true, _id);
-        }
-        (verified,) = address(this).verifySignal(root, ticket.chainId, _id, accountProof, storageProof);
-        return (verified, _id);
+        ISignalService(signalService).verifySignal(address(this), root, ticket.chainId, _id, accountProof, storageProof);
+        // true because call will revert otherwise
+        return (true, _id);
     }
 
     /// @dev Creates a ticket with `msg.value` ETH for the receiver (`to`) to claim on the `destinationChainId`.
-    function createTicket(uint64 destinationChainId, address from, address to, uint256 value)
+    function createTicket(uint64 destinationChainId, address from, address to, uint256 value, address signalService)
         internal
-        returns (ValueTicket memory ticket)
+        returns (ValueTicket memory)
     {
         ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
         bytes32 _id = id(ticket);
-        _id.signal();
-        return ticket;
+        ISignalService(signalService).sendSignal(_id);
     }
 
     /// @dev Creates a ticket with `msg.value` ETH for the receiver (`to`) to claim on the `destinationChainId`.
@@ -78,8 +71,7 @@ library LibValueTicket {
     {
         ticket = ValueTicket(destinationChainId, _useNonce(from).toUint64(), from, to, value);
         bytes32 _id = id(ticket);
-        ISignalService(signalService).sendSignal(_id);
-        return ticket;
+        ISignalService(signalService).sendFastSignal(_id);
     }
 
     /// @dev Reverts if a ticket was not created by `from` with `nonce` on `chainId`. See `verifyTicket`.

--- a/src/protocol/ETHBridge.sol
+++ b/src/protocol/ETHBridge.sol
@@ -44,7 +44,7 @@ contract ETHBridge is IETHBridge {
 
     /// @inheritdoc IETHBridge
     function createTicket(uint64 chainId, address to) external payable virtual {
-        emit ETHTicket(LibValueTicket.createTicket(chainId, msg.sender, to, msg.value));
+        emit ETHTicket(LibValueTicket.createTicket(chainId, msg.sender, to, msg.value, signalService));
     }
 
     /// @inheritdoc IETHBridge

--- a/src/protocol/ISignalService.sol
+++ b/src/protocol/ISignalService.sol
@@ -8,8 +8,11 @@ interface ISignalService {
     error CallerNotAuthorised();
 
     event SignalsReceived(bytes32[] signalSlots);
+    event FastSignalSent(bytes32 signal);
+    event SignalSent(bytes32 signal);
 
     function sendSignal(bytes32 value) external returns (bytes32);
+    function sendFastSignal(bytes32 value) external returns (bytes32);
 
     function receiveSignals(bytes32[] calldata signalSlots) external;
 

--- a/src/protocol/SignalService.sol
+++ b/src/protocol/SignalService.sol
@@ -26,8 +26,15 @@ contract SignalService is ISignalService {
     }
 
     /// @dev Only required to be called on L1
-    function sendSignal(bytes32 value) external returns (bytes32) {
-        return value.signal();
+    function sendSignal(bytes32 value) external returns (bytes32 signal) {
+        signal = value.signal();
+        emit SignalSent(signal);
+    }
+
+    /// @dev Only required to be called on L1
+    function sendFastSignal(bytes32 value) external returns (bytes32 signal) {
+        signal = value.signal();
+        emit FastSignalSent(signal);
     }
 
     /// @dev Only required to be called on L2


### PR DESCRIPTION
POC to see what it would look like for the Signal Service to also store 'slow' signals. Added an explicit fast signal and fast signal event to make it easier for the proposer to filter / inject same slot signals.