### PR TITLE
Simplify CheckpointTracker

### DIFF
--- a/src/protocol/CheckpointTracker.sol
+++ b/src/protocol/CheckpointTracker.sol
@@ -36,7 +36,7 @@ contract CheckpointTracker is ICheckpointTracker {
     /// @inheritdoc ICheckpointTracker
     function proveTransition(Checkpoint calldata start, Checkpoint calldata end, bytes calldata proof) external {
         require(end.commitment != 0, "Checkpoint commitment cannot be 0");
-        
+
         bytes32 startCheckpointHash = keccak256(abi.encode(start));
         require(startCheckpointHash == provenHash, "Start checkpoint must be the latest proven checkpoint");
 
@@ -46,13 +46,7 @@ contract CheckpointTracker is ICheckpointTracker {
         bytes32 endPublicationHash = publicationFeed.getPublicationHash(end.publicationId);
         require(endPublicationHash != 0, "End publication does not exist");
 
-        verifier.verifyProof(
-            startPublicationHash,
-            endPublicationHash,
-            start.commitment,
-            end.commitment,
-            proof
-        );
+        verifier.verifyProof(startPublicationHash, endPublicationHash, start.commitment, end.commitment, proof);
 
         provenHash = keccak256(abi.encode(end));
         emit TransitionProven(start, end);

--- a/test/CheckpointTracker.t.sol
+++ b/test/CheckpointTracker.t.sol
@@ -115,14 +115,4 @@ contract CheckpointTrackerTest is Test {
         checkpoint = ICheckpointTracker.Checkpoint({publicationId: pubId, commitment: commitment});
         hash = keccak256(abi.encode(checkpoint));
     }
-
-    // function createSampleCheckpoints() private {
-    //     ICheckpointTracker.Checkpoint memory memCheckpoint;
-    //     bytes32 checkpointHash;
-    //     for (uint256 i; i < NUM_PUBLICATIONS; ++i) {
-    //         (memCheckpoint, checkpointHash) = createCheckpoint(i, keccak256(abi.encode(i)));
-    //         checkpoints.push(memCheckpoint);
-    //         hashes.push(checkpointHash);
-    //     }
-    // }
 }

--- a/test/CheckpointTracker.t.sol
+++ b/test/CheckpointTracker.t.sol
@@ -19,20 +19,82 @@ contract CheckpointTrackerTest is Test {
     bytes proof;
 
     uint256 NUM_PUBLICATIONS;
-    uint256 EXCESS_CHECKPOINTS;
 
     function setUp() public {
         NUM_PUBLICATIONS = 20;
-        EXCESS_CHECKPOINTS = 5;
 
         verifier = new NullVerifier();
 
         feed = new PublicationFeed();
         createSampleFeed();
 
-        tracker = new CheckpointTracker(keccak256(abi.encode(0)), address(feed), address(verifier));
-        createSampleCheckpoints();
+        tracker = new CheckpointTracker(keccak256(abi.encode("genesis")), address(feed), address(verifier));
+        // createSampleCheckpoints();
         proof = abi.encode("proof");
+    }
+
+    function test_setUp() public {
+        ICheckpointTracker.Checkpoint memory genesisCheckpoint =
+            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
+        assertEq(tracker.provenHash(), keccak256(abi.encode(genesisCheckpoint)));
+    }
+
+    function test_constructor_RevertWhenGenesisIsZero() public {
+        vm.expectRevert("genesis checkpoint commitment cannot be 0");
+        new CheckpointTracker(bytes32(0), address(feed), address(verifier));
+    }
+
+    function test_constructor_EmitsEvent() public {
+        ICheckpointTracker.Checkpoint memory genesisCheckpoint =
+            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
+        bytes32 genesisHash = keccak256(abi.encode(genesisCheckpoint));
+
+        vm.expectEmit();
+        emit ICheckpointTracker.CheckpointUpdated(genesisHash);
+        new CheckpointTracker(keccak256(abi.encode("genesis")), address(feed), address(verifier));
+    }
+
+    function test_proveTransition_SuccessfulTransition() public {
+        ICheckpointTracker.Checkpoint memory start =
+            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
+        ICheckpointTracker.Checkpoint memory end =
+            ICheckpointTracker.Checkpoint({publicationId: 3, commitment: keccak256(abi.encode("end"))});
+
+        vm.expectEmit();
+        emit ICheckpointTracker.TransitionProven(start, end);
+        tracker.proveTransition(start, end, proof);
+
+        assertEq(tracker.provenHash(), keccak256(abi.encode(end)));
+    }
+
+    function test_proveTransition_RevertWhenEndCommitmentIsZero() public {
+        ICheckpointTracker.Checkpoint memory start =
+            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
+        ICheckpointTracker.Checkpoint memory end =
+            ICheckpointTracker.Checkpoint({publicationId: 3, commitment: bytes32(0)});
+
+        vm.expectRevert("Checkpoint commitment cannot be 0");
+        tracker.proveTransition(start, end, proof);
+    }
+
+    function test_proveTransition_RevertWhenStartCheckpointNotLatestProven() public {
+        ICheckpointTracker.Checkpoint memory start =
+            ICheckpointTracker.Checkpoint({publicationId: 1, commitment: keccak256(abi.encode("wrong"))});
+        ICheckpointTracker.Checkpoint memory end =
+            ICheckpointTracker.Checkpoint({publicationId: 3, commitment: keccak256(abi.encode("end"))});
+
+        vm.expectRevert("Start checkpoint must be the latest proven checkpoint");
+        tracker.proveTransition(start, end, proof);
+    }
+
+    function test_proveTransition_RevertWhenEndPublicationNotAfterStart() public {
+        ICheckpointTracker.Checkpoint memory start =
+            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
+        ICheckpointTracker.Checkpoint memory end =
+            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("end"))});
+
+        vm.expectRevert("End publication must be after the last proven publication");
+        tracker.proveTransition(start, end, proof);
     }
 
     function createSampleFeed() private {
@@ -54,113 +116,13 @@ contract CheckpointTrackerTest is Test {
         hash = keccak256(abi.encode(checkpoint));
     }
 
-    function createSampleCheckpoints() private {
-        ICheckpointTracker.Checkpoint memory memCheckpoint;
-        bytes32 checkpointHash;
-        for (uint256 i; i < NUM_PUBLICATIONS + EXCESS_CHECKPOINTS; ++i) {
-            (memCheckpoint, checkpointHash) = createCheckpoint(i, keccak256(abi.encode(i)));
-            checkpoints.push(memCheckpoint);
-            hashes.push(checkpointHash);
-        }
-    }
-
-    function test_Setup_CheckpointIsGenesis() public view {
-        assertEq(tracker.provenHash(), hashes[0]);
-    }
-
-    function test_DisconnectedTransition_ProvenUnchanged() public {
-        tracker.proveTransition(checkpoints[3], checkpoints[5], proof);
-        assertEq(tracker.provenHash(), hashes[0]);
-    }
-
-    function test_DisconnectedTransition_TransitionUpdated() public {
-        assertEq(tracker.transitions(hashes[3]), 0);
-        tracker.proveTransition(checkpoints[3], checkpoints[5], proof);
-        assertNotEq(tracker.transitions(hashes[3]), 0);
-        assertEq(tracker.transitions(hashes[3]), hashes[5]);
-    }
-
-    function test_NextTransition_ProvenUpdated() public {
-        tracker.proveTransition(checkpoints[0], checkpoints[5], proof);
-        assertNotEq(tracker.provenHash(), hashes[0]);
-        assertEq(tracker.provenHash(), hashes[5]);
-    }
-
-    function test_NextTransition_TransitionNotUpdated() public {
-        assertEq(tracker.transitions(hashes[0]), 0);
-        tracker.proveTransition(checkpoints[0], checkpoints[5], proof);
-        assertEq(tracker.transitions(hashes[0]), 0);
-    }
-
-    function testRevert_DuplicateTransition() public {
-        tracker.proveTransition(checkpoints[3], checkpoints[5], proof);
-        vm.expectRevert();
-        tracker.proveTransition(checkpoints[3], checkpoints[7], proof);
-    }
-
-    function testRevert_TransitionOutOfBounds() public {
-        vm.expectRevert();
-        tracker.proveTransition(checkpoints[18], checkpoints[23], proof);
-    }
-
-    function test_LastTransition() public {
-        // does not revert
-        tracker.proveTransition(checkpoints[18], checkpoints[NUM_PUBLICATIONS], proof);
-    }
-
-    function testRevert_BackwardsTransition() public {
-        vm.expectRevert();
-        tracker.proveTransition(checkpoints[5], checkpoints[3], proof);
-    }
-
-    function test_TwoStepUpdate() public {
-        tracker.proveTransition(checkpoints[6], checkpoints[8], proof);
-        assertEq(tracker.provenHash(), hashes[0]); // checkpoint not updated
-        assertEq(tracker.transitions(hashes[6]), hashes[8]);
-
-        tracker.proveTransition(checkpoints[0], checkpoints[6], proof);
-        assertEq(tracker.provenHash(), hashes[8]); // checkpoint updated over both transitions
-    }
-
-    function test_ChainedUpdates() public {
-        // 6 -> 8
-        tracker.proveTransition(checkpoints[6], checkpoints[8], proof);
-        assertEq(tracker.provenHash(), hashes[0]); // checkpoint not updated
-        assertEq(tracker.transitions(hashes[6]), hashes[8]);
-
-        // 2 -> 6 -> 8
-        tracker.proveTransition(checkpoints[2], checkpoints[6], proof);
-        assertEq(tracker.provenHash(), hashes[0]); // checkpoint not updated
-        assertEq(tracker.transitions(hashes[2]), hashes[6]);
-
-        // 2 -> 6 -> 8 -> 11
-        tracker.proveTransition(checkpoints[8], checkpoints[11], proof);
-        assertEq(tracker.provenHash(), hashes[0]); // checkpoint not updated
-        assertEq(tracker.transitions(hashes[8]), hashes[11]);
-
-        // 2 -> 6 -> 8 -> 11; 15 -> 16
-        tracker.proveTransition(checkpoints[15], checkpoints[16], proof);
-        assertEq(tracker.provenHash(), hashes[0]); // checkpoint not updated
-        assertEq(tracker.transitions(hashes[15]), hashes[16]);
-
-        tracker.proveTransition(checkpoints[0], checkpoints[2], proof);
-        // checkpoint updated over chain (to 11) but not to latest checkpoint (16)
-        assertEq(tracker.provenHash(), hashes[11]);
-    }
-
-    function test_UpdateLimits() public {
-        // set up individual transitions between 2 to 15
-        for (uint256 i = 2; i < 15; i++) {
-            tracker.proveTransition(checkpoints[i], checkpoints[i + 1], proof);
-        }
-
-        // prove 0 -> 2 to start the chain of updates
-        tracker.proveTransition(checkpoints[0], checkpoints[2], proof);
-        // do exactly MAX_EXTRA_UPDATES (10) additional updates
-        assertEq(tracker.provenHash(), hashes[12]);
-
-        // another proof will complete the update chain
-        tracker.proveTransition(checkpoints[17], checkpoints[19], proof);
-        assertEq(tracker.provenHash(), hashes[15]);
-    }
+    // function createSampleCheckpoints() private {
+    //     ICheckpointTracker.Checkpoint memory memCheckpoint;
+    //     bytes32 checkpointHash;
+    //     for (uint256 i; i < NUM_PUBLICATIONS; ++i) {
+    //         (memCheckpoint, checkpointHash) = createCheckpoint(i, keccak256(abi.encode(i)));
+    //         checkpoints.push(memCheckpoint);
+    //         hashes.push(checkpointHash);
+    //     }
+    // }
 }

--- a/test/CheckpointTracker.t.sol
+++ b/test/CheckpointTracker.t.sol
@@ -29,7 +29,6 @@ contract CheckpointTrackerTest is Test {
         createSampleFeed();
 
         tracker = new CheckpointTracker(keccak256(abi.encode("genesis")), address(feed), address(verifier));
-        // createSampleCheckpoints();
         proof = abi.encode("proof");
     }
 


### PR DESCRIPTION
Fixes #56 

We discussed that with the correct incentive mechanism for provers(#49 ) we could get rid of parallel proving and the concept of transitions all together. This PR changes the CheckpointTracker to store only the latest checkpoint. Older checkpoints should be synced to the SignalService or CheckpointSyncer once we decide where we want to store them.

- Only store the latest checkpoint hash
- Modify unit tests