### PR TITLE
Use a queue and binary search to process delayed inclusions

### DIFF
--- a/src/protocol/IDelayedInclusionStore.sol
+++ b/src/protocol/IDelayedInclusionStore.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.28;
 
 interface IDelayedInclusionStore {
+    // TODO: should we use different types for stored inclusion and what we return to the inbox? i.e the inbox does not need the due timestamp
     struct Inclusion {
         bytes32 blobRefHash;
-        uint256 timestamp;
+        uint256 due;
     }
 
     /// @notice Returns a list of publications that should be processed by the Inbox

--- a/src/protocol/IDelayedInclusionStore.sol
+++ b/src/protocol/IDelayedInclusionStore.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.28;
 
 interface IDelayedInclusionStore {
-    // TODO: should we use different types for stored inclusion and what we return to the inbox? i.e the inbox does not need the due timestamp
+    // TODO: should we use different types for stored inclusion and what we return to the inbox? i.e the inbox does not
+    // need the due timestamp
     struct Inclusion {
         bytes32 blobRefHash;
         uint256 due;

--- a/src/protocol/taiko_alethia/DelayedInclusionStore.sol
+++ b/src/protocol/taiko_alethia/DelayedInclusionStore.sol
@@ -5,7 +5,6 @@ import {IBlobRefRegistry} from "../../blobs/IBlobRefRegistry.sol";
 import {IDelayedInclusionStore} from "../IDelayedInclusionStore.sol";
 
 contract DelayedInclusionStore is IDelayedInclusionStore {
-    
     // Append-only queue for delayed inclusions
     Inclusion[] private delayedInclusions;
     // Pointer to the first unprocessed element
@@ -69,10 +68,11 @@ contract DelayedInclusionStore is IDelayedInclusionStore {
 
         // Allocate a new array for due inclusions.
         Inclusion[] memory inclusions = new Inclusion[](count);
-        for (uint256 i = 0; i < count; ++i ) {
-            inclusions[i] = Inclusion({ blobRefHash: delayedInclusions[head + i].blobRefHash, due: delayedInclusions[head + i].due });
+        for (uint256 i = 0; i < count; ++i) {
+            inclusions[i] =
+                Inclusion({blobRefHash: delayedInclusions[head + i].blobRefHash, due: delayedInclusions[head + i].due});
         }
-        
+
         // Move the head pointer forward.
         head = l;
 

--- a/test/DelayedInclusionStore.t.sol
+++ b/test/DelayedInclusionStore.t.sol
@@ -35,9 +35,24 @@ contract DelayedInclusionStoreTest is Test {
         }
     }
 
-    function test_processDueInclusions() public {
+    function test_processHalfDueInclusions() public {
         vm.prank(inbox);
         vm.warp(inclusionDelay + 1);
+        uint256 returnLen = store.processDueInclusions().length;
+        assertEq(returnLen, 25);
+    }
+
+    function test_processAllDueInclusions() public {
+        vm.prank(inbox);
+        vm.warp(inclusionDelay + 2 hours + 1);
         store.processDueInclusions();
+        uint256 returnLen = store.processDueInclusions().length;
+        assertEq(returnLen, 50);
+    }
+
+    function test_processDueInclusions_noInclusions() public {
+        vm.prank(inbox);
+        uint256 returnLen = store.processDueInclusions().length;
+        assertEq(returnLen, 0);
     }
 }

--- a/test/DelayedInclusionStore.t.sol
+++ b/test/DelayedInclusionStore.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {StdStorage, stdStorage} from "forge-std/Test.sol";
+
+import {IDelayedInclusionStore} from "src/protocol/IDelayedInclusionStore.sol";
+import {DelayedInclusionStore} from "src/protocol/taiko_alethia/DelayedInclusionStore.sol";
+import {MockBlobRefRegistry} from "test/mocks/MockBlobRefRegistry.sol";
+
+contract DelayedInclusionStoreTest is Test {
+    using stdStorage for StdStorage;
+
+    DelayedInclusionStore store;
+    MockBlobRefRegistry blobReg;
+    // Addresses used for testing.
+    address inbox = address(0x100);
+
+    uint256 public inclusionDelay = 10 minutes;
+
+    function setUp() public {
+        blobReg = new MockBlobRefRegistry();
+        store = new DelayedInclusionStore(inclusionDelay, address(blobReg), inbox);
+        storeDelayedInclusions(25);
+        vm.warp(2 hours);
+        storeDelayedInclusions(25);
+        vm.warp(1);
+    }
+
+    function storeDelayedInclusions(uint256 numInclusions) public {
+        for (uint256 i; i < numInclusions; ++i) {
+            uint256[] memory blobIndices = new uint256[](1);
+            blobIndices[0] = i;
+            store.publishDelayed(blobIndices);
+        }
+    }
+
+    function test_processDueInclusions() public {
+        vm.prank(inbox);
+        vm.warp(inclusionDelay + 1);
+        store.processDueInclusions();
+    }
+}

--- a/test/mocks/MockBlobRefRegistry.sol
+++ b/test/mocks/MockBlobRefRegistry.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IBlobRefRegistry} from "../../src/blobs/IBlobRefRegistry.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract MockBlobRefRegistry is Test {
+    function getRef(uint256[] calldata blobIndices) external view returns (IBlobRefRegistry.BlobRef memory) {
+        uint256 nBlobs = blobIndices.length;
+
+        bytes32[] memory blobhashes = new bytes32[](nBlobs);
+        for (uint256 i; i < nBlobs; ++i) {
+            // simulate a blobhash
+            blobhashes[i] = keccak256(abi.encode(vm.randomUint(256)));
+        }
+        return IBlobRefRegistry.BlobRef(block.number, blobhashes);
+    }
+}


### PR DESCRIPTION
A different approach for processing delayed inclusions. This should be more gas efficient:
- Go back to using an append only queue instead of a mapping
- Use a binary search to decide what inclusions to process, taking advantage of the fact that inclusions are ordered by due date
- Only check msg.sender once we know there are inclusions to process