### PR TITLE
Prove publication count

### DIFF
--- a/documentation/Overall Design.md
+++ b/documentation/Overall Design.md
@@ -75,6 +75,7 @@ These properties seem like they should be useful for composability. However:
 
 - we have not yet designed any features that rely on them.
 - the shared feed undermines the ability to recognise when a publication is no longer required, so  <span style="color: orange;">it prevents the use of a ring buffer</span>.
+- we cannot compute the number of relevant publications between two publication ids, so we need to pass this as a separate parameter to the proof.
 
 If we do not implement any composability features, we should restore the different publication feeds per rollup so the implementation can be optimised.
 

--- a/src/protocol/CheckpointTracker.sol
+++ b/src/protocol/CheckpointTracker.sol
@@ -35,7 +35,12 @@ contract CheckpointTracker is ICheckpointTracker {
     }
 
     /// @inheritdoc ICheckpointTracker
-    function proveTransition(Checkpoint calldata start, Checkpoint calldata end, bytes calldata proof) external {
+    function proveTransition(
+        Checkpoint calldata start,
+        Checkpoint calldata end,
+        uint256 numPublications,
+        bytes calldata proof
+    ) external {
         require(
             proverManager == address(0) || msg.sender == proverManager, "Only the prover manager can call this function"
         );
@@ -51,7 +56,9 @@ contract CheckpointTracker is ICheckpointTracker {
         bytes32 endPublicationHash = publicationFeed.getPublicationHash(end.publicationId);
         require(endPublicationHash != 0, "End publication does not exist");
 
-        verifier.verifyProof(startPublicationHash, endPublicationHash, start.commitment, end.commitment, proof);
+        verifier.verifyProof(
+            startPublicationHash, endPublicationHash, start.commitment, end.commitment, numPublications, proof
+        );
 
         provenHash = keccak256(abi.encode(end));
         emit TransitionProven(start, end);

--- a/src/protocol/ICheckpointTracker.sol
+++ b/src/protocol/ICheckpointTracker.sol
@@ -22,14 +22,14 @@ interface ICheckpointTracker {
     /// @notice Verifies a transition between two checkpoints. Update the latest `provenCheckpoint` if possible
     /// @param start The initial checkpoint before the transition
     /// @param end The final checkpoint after the transition
-    /// @param nPublications The number of publications that need to be processed between the two checkpoints.
+    /// @param numPublications The number of publications that need to be processed between the two checkpoints.
     /// Note that this is not necessarily (end.publicationId - start.publicationId) because there could be irrelevant
     /// publications.
     /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
     function proveTransition(
         Checkpoint calldata start,
         Checkpoint calldata end,
-        uint256 nPublications,
+        uint256 numPublications,
         bytes calldata proof
     ) external;
 }

--- a/src/protocol/ICheckpointTracker.sol
+++ b/src/protocol/ICheckpointTracker.sol
@@ -22,6 +22,14 @@ interface ICheckpointTracker {
     /// @notice Verifies a transition between two checkpoints. Update the latest `provenCheckpoint` if possible
     /// @param start The initial checkpoint before the transition
     /// @param end The final checkpoint after the transition
+    /// @param nPublications The number of publications that need to be processed between the two checkpoints.
+    /// Note that this is not necessarily (end.publicationId - start.publicationId) because there could be irrelevant
+    /// publications.
     /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
-    function proveTransition(Checkpoint calldata start, Checkpoint calldata end, bytes calldata proof) external;
+    function proveTransition(
+        Checkpoint calldata start,
+        Checkpoint calldata end,
+        uint256 nPublications,
+        bytes calldata proof
+    ) external;
 }

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -46,8 +46,6 @@ interface IProverManager {
     /// @param endPublicationHeader The end publication header
     /// @param numPublications The number of publications to process. This is not implied by the start/end publication
     /// ids because there could be irrelevant publications.
-    /// @param nextPublicationHeaderBytes Optional parameter that should only be sent when the prover has finished all
-    /// their publications for the period.
     /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
     /// @param periodId The id of the period for which the proof is submitted
     function proveOpenPeriod(
@@ -56,7 +54,6 @@ interface IProverManager {
         IPublicationFeed.PublicationHeader calldata startPublicationHeader,
         IPublicationFeed.PublicationHeader calldata endPublicationHeader,
         uint256 numPublications,
-        bytes calldata nextPublicationHeaderBytes,
         bytes calldata proof,
         uint256 periodId
     ) external;

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -35,11 +35,10 @@ interface IProverManager {
         ICheckpointTracker.Checkpoint calldata lastProven
     ) external;
 
-    /// @notice Submits a proof for an open period
-    /// @dev An open period is not necessarily the current period, it just means that the prover is within their
-    /// deadline.
-    /// @dev If the prover has finished all their publications for the period, they can also claim the fees and their
-    /// liveness bond.
+    /// @notice Submits a proof.
+    /// @dev If called after the proof deadline, the caller becomes the new prover and some of the original prover's
+    /// stake is burned
+    /// @dev In either case the (possibly new) prover gets the fee for all proven publications
     /// @param start The initial checkpoint before the transition
     /// @param end The final checkpoint after the transition
     /// @param startPublicationHeader The start publication header
@@ -48,27 +47,7 @@ interface IProverManager {
     /// ids because there could be irrelevant publications.
     /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
     /// @param periodId The id of the period for which the proof is submitted
-    function proveOpenPeriod(
-        ICheckpointTracker.Checkpoint calldata start,
-        ICheckpointTracker.Checkpoint calldata end,
-        IPublicationFeed.PublicationHeader calldata startPublicationHeader,
-        IPublicationFeed.PublicationHeader calldata endPublicationHeader,
-        uint256 numPublications,
-        bytes calldata proof,
-        uint256 periodId
-    ) external;
-
-    /// @notice Called by a prover when the originally assigned prover is passed its deadline
-    /// @dev This function should slash the prover and distribute their stake to compensate the new prover
-    /// @param start The initial checkpoint before the transition
-    /// @param end The final checkpoint after the transition
-    /// @param startPublicationHeader The start publication header
-    /// @param endPublicationHeader The end publication header
-    /// @param numPublications The number of publications to process. This is not implied by the start/end publication
-    /// ids because there could be irrelevant publications.
-    /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
-    /// @param periodId The id of the period for which the proof is submitted
-    function proveClosedPeriod(
+    function prove(
         ICheckpointTracker.Checkpoint calldata start,
         ICheckpointTracker.Checkpoint calldata end,
         IPublicationFeed.PublicationHeader calldata startPublicationHeader,

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -66,7 +66,6 @@ interface IProverManager {
     /// @param endPublicationHeader The end publication header
     /// @param numPublications The number of publications to process. This is not implied by the start/end publication
     /// ids because there could be irrelevant publications.
-    /// @param nextPublicationHeader The next publication header. It should be after the period end
     /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
     /// @param periodId The id of the period for which the proof is submitted
     function proveClosedPeriod(
@@ -75,7 +74,6 @@ interface IProverManager {
         IPublicationFeed.PublicationHeader calldata startPublicationHeader,
         IPublicationFeed.PublicationHeader calldata endPublicationHeader,
         uint256 numPublications,
-        IPublicationFeed.PublicationHeader calldata nextPublicationHeader,
         bytes calldata proof,
         uint256 periodId
     ) external;

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -58,17 +58,15 @@ interface IProverManager {
     ) external;
 
     /// @notice Returns the stake for a closed period to the prover
-    /// @dev Only needed if the period was not finalized during its last proof.
-    /// @dev This could occur if the prover did not specify a later publication (possibly because it did not exist at
-    /// the time)
     /// @param periodId The id of the period to finalize
     /// @param lastProven The last proven checkpoint. TODO: we should save the actual checkpoint (not the hash) in
     /// CheckpointTracker so we can query it directly
-    /// @param provenPublicationHeaderBytes Optional parameter if needed to demonstrate there is a proven publication
-    /// after the period
+    /// @param provenPublication A publication after the period that has been proven
+    /// @dev If there is a proven publication after the period, it implies the whole period has been proven.
+    /// @dev We assume there will always be a suitable (and timely) proven publication.
     function finalizeClosedPeriod(
         uint256 periodId,
         ICheckpointTracker.Checkpoint calldata lastProven,
-        bytes calldata provenPublicationHeaderBytes
+        IPublicationFeed.PublicationHeader calldata provenPublication
     ) external;
 }

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -44,6 +44,8 @@ interface IProverManager {
     /// @param end The final checkpoint after the transition
     /// @param startPublicationHeader The start publication header
     /// @param endPublicationHeader The end publication header
+    /// @param numPublications The number of publications to process. This is not implied by the start/end publication
+    /// ids because there could be irrelevant publications.
     /// @param nextPublicationHeaderBytes Optional parameter that should only be sent when the prover has finished all
     /// their publications for the period.
     /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
@@ -53,6 +55,7 @@ interface IProverManager {
         ICheckpointTracker.Checkpoint calldata end,
         IPublicationFeed.PublicationHeader calldata startPublicationHeader,
         IPublicationFeed.PublicationHeader calldata endPublicationHeader,
+        uint256 numPublications,
         bytes calldata nextPublicationHeaderBytes,
         bytes calldata proof,
         uint256 periodId

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -65,14 +65,19 @@ interface IProverManager {
     /// @dev This function should slash the prover and distribute their stake to compensate the new prover
     /// @param start The initial checkpoint before the transition
     /// @param end The final checkpoint after the transition
-    /// @param publicationHeadersToProve The chain of publication headers to prove
+    /// @param startPublicationHeader The start publication header
+    /// @param endPublicationHeader The end publication header
+    /// @param numPublications The number of publications to process. This is not implied by the start/end publication
+    /// ids because there could be irrelevant publications.
     /// @param nextPublicationHeader The next publication header. It should be after the period end
     /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
     /// @param periodId The id of the period for which the proof is submitted
     function proveClosedPeriod(
         ICheckpointTracker.Checkpoint calldata start,
         ICheckpointTracker.Checkpoint calldata end,
-        IPublicationFeed.PublicationHeader[] calldata publicationHeadersToProve,
+        IPublicationFeed.PublicationHeader calldata startPublicationHeader,
+        IPublicationFeed.PublicationHeader calldata endPublicationHeader,
+        uint256 numPublications,
         IPublicationFeed.PublicationHeader calldata nextPublicationHeader,
         bytes calldata proof,
         uint256 periodId

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -12,7 +12,7 @@ interface IProverManager {
     /// @notice The current prover can signal exit to eventually pull out their liveness bond.
     function exit() external;
 
-    /// @notice If there is no active prover, start a new period and become the new prover immediately
+    /// @notice If there is no active prover, start a new period and become the new prover in the next block
     /// @param fee The per-publication fee for the new period
     /// @dev Consider the scenario:
     ///   - a prover has exited or been evicted

--- a/src/protocol/IVerifier.sol
+++ b/src/protocol/IVerifier.sol
@@ -8,6 +8,7 @@ interface IVerifier {
         bytes32 endPublicationHash,
         bytes32 startCheckPoint,
         bytes32 endCheckPoint,
+        uint256 numPublications,
         bytes calldata proof
     ) external;
 }

--- a/src/protocol/taiko_alethia/ProverManager.sol
+++ b/src/protocol/taiko_alethia/ProverManager.sol
@@ -245,13 +245,10 @@ contract ProverManager is IProposerFees, IProverManager {
         uint256 periodId = currentPeriodId;
         Period storage period = _periods[periodId];
         require(period.prover == address(0) && period.end == 0, "No proving vacancy");
+        period.end = period.deadline = block.timestamp;
 
-        // Advance to the next period
-        currentPeriodId = ++periodId;
-        emit NewPeriod(periodId);
-
-        period = _periods[periodId];
-        _updatePeriod(period, msg.sender, fee, livenessBond);
+        Period storage nextPeriod = _periods[periodId + 1];
+        _updatePeriod(nextPeriod, msg.sender, fee, livenessBond);
     }
 
     /// @inheritdoc IProverManager

--- a/src/protocol/taiko_alethia/ProverManager.sol
+++ b/src/protocol/taiko_alethia/ProverManager.sol
@@ -297,7 +297,7 @@ contract ProverManager is IProposerFees, IProverManager {
     ) external {
         Period storage period = _periods[periodId];
         uint256 periodEnd = period.end;
-        require(block.timestamp > period.deadline, "The period is still open");
+        require(period.deadline != 0 && block.timestamp > period.deadline, "The period is still open");
 
         uint256 previousPeriodEnd = 0;
         if (periodId > 0) {

--- a/src/protocol/taiko_alethia/ProverManager.sol
+++ b/src/protocol/taiko_alethia/ProverManager.sol
@@ -171,7 +171,7 @@ contract ProverManager is IProposerFees, IProverManager {
         Period storage _currentPeriod = _periods[currentPeriod];
         Period storage _nextPeriod = _periods[currentPeriod + 1];
         uint256 requiredMaxFee;
-        if (_isPeriodActive(_currentPeriod.end)) {
+        if (_currentPeriod.end == 0) {
             // If the period is still active the bid has to be lower
             uint256 currentFee = _currentPeriod.fee;
             requiredMaxFee = _calculatePercentage(currentFee, maxBidPercentage);
@@ -182,7 +182,7 @@ contract ProverManager is IProposerFees, IProverManager {
             _currentPeriod.deadline = periodEnd + provingWindow;
         } else {
             address _nextProverAddress = _nextPeriod.prover;
-            if (_isBidded(_nextProverAddress)) {
+            if (_nextProverAddress != address(0)) {
                 // If there's already a bid for the next period the bid has to be lower
                 uint256 nextFee = _nextPeriod.fee;
                 requiredMaxFee = _calculatePercentage(nextFee, maxBidPercentage);
@@ -337,20 +337,6 @@ contract ProverManager is IProposerFees, IProverManager {
     /// @return _ The calculated percentage of the given numerator
     function _calculatePercentage(uint256 amount, uint256 bps) private pure returns (uint256) {
         return (amount * bps) / 10_000;
-    }
-
-    /// @dev Checks if a period is active based on its end timestamp
-    /// @param end The end timestamp of the period
-    /// @return True if the period is active, false otherwise
-    function _isPeriodActive(uint256 end) private pure returns (bool) {
-        return end == 0;
-    }
-
-    /// @dev Checks if a period is already bidded
-    /// @param prover The address of the prover
-    /// @return True if someone has already bid for the period, false otherwise
-    function _isBidded(address prover) private pure returns (bool) {
-        return prover != address(0);
     }
 
     function _isClosed(uint256 periodEnd, ICheckpointTracker.Checkpoint calldata lastProven, bytes calldata headerBytes)

--- a/src/protocol/taiko_alethia/ProverManager.sol
+++ b/src/protocol/taiko_alethia/ProverManager.sol
@@ -305,13 +305,9 @@ contract ProverManager is IProposerFees, IProverManager {
             previousPeriodEnd = previousPeriod.end;
         }
 
-        // Ensure that publications are inside the period
-        require(endPublicationHeader.timestamp <= periodEnd, "End publication is not within the period");
-        require(startPublicationHeader.timestamp > previousPeriodEnd, "Start publication is not within the period");
-
-        // Ensure that checkpoints actually match the publications
-        require(start.publicationId == startPublicationHeader.id, "Start checkpoint publication ID mismatch");
-        require(end.publicationId == endPublicationHeader.id, "End checkpoint publication ID mismatch");
+        _validateBasePublications(
+            start, end, startPublicationHeader, endPublicationHeader, periodEnd, previousPeriodEnd
+        );
 
         checkpointTracker.proveTransition(start, end, numPublications, proof);
         balances[msg.sender] += period.fee * numPublications;

--- a/src/protocol/taiko_alethia/ProverManager.sol
+++ b/src/protocol/taiko_alethia/ProverManager.sol
@@ -261,7 +261,6 @@ contract ProverManager is IProposerFees, IProverManager {
         IPublicationFeed.PublicationHeader calldata startPublicationHeader,
         IPublicationFeed.PublicationHeader calldata endPublicationHeader,
         uint256 numPublications,
-        bytes calldata nextPublicationHeaderBytes,
         bytes calldata proof,
         uint256 periodId
     ) external {
@@ -281,17 +280,6 @@ contract ProverManager is IProposerFees, IProverManager {
 
         checkpointTracker.proveTransition(start, end, numPublications, proof);
         balances[period.prover] += numPublications * period.fee;
-
-        if (nextPublicationHeaderBytes.length > 0) {
-            // This means that the prover is claiming that they have finished all their publications for the period
-            IPublicationFeed.PublicationHeader memory nextPub =
-                abi.decode(nextPublicationHeaderBytes, (IPublicationFeed.PublicationHeader));
-            _validateNextPublicationHeader(nextPub, end.publicationId + 1, periodEnd);
-
-            // Finalize the period: transfer stake.
-            balances[period.prover] += period.stake;
-            period.stake = 0;
-        }
     }
 
     /// @inheritdoc IProverManager

--- a/src/protocol/taiko_alethia/ProverManager.sol
+++ b/src/protocol/taiko_alethia/ProverManager.sol
@@ -484,10 +484,11 @@ contract ProverManager is IProposerFees, IProverManager {
     /// @param period The period to update
     /// @param prover The address of the prover
     /// @param fee The fee offered by the prover
+    /// @param stake The liveness bond to be staked
     function _updatePeriod(Period storage period, address prover, uint256 fee, uint256 stake) private {
         period.prover = prover;
         period.fee = fee;
-        period.stake = stake;
+        period.stake = stake; // overwrite previous value. We assume the previous value is zero or already returned
         balances[prover] -= stake;
     }
 }

--- a/src/protocol/taiko_alethia/ProverManager.sol
+++ b/src/protocol/taiko_alethia/ProverManager.sol
@@ -264,6 +264,7 @@ contract ProverManager is IProposerFees, IProverManager {
         ICheckpointTracker.Checkpoint calldata end,
         IPublicationFeed.PublicationHeader calldata startPublicationHeader,
         IPublicationFeed.PublicationHeader calldata endPublicationHeader,
+        uint256 numPublications,
         bytes calldata nextPublicationHeaderBytes,
         bytes calldata proof,
         uint256 periodId
@@ -282,7 +283,7 @@ contract ProverManager is IProposerFees, IProverManager {
             start, end, startPublicationHeader, endPublicationHeader, periodEnd, previousPeriodEnd
         );
 
-        checkpointTracker.proveTransition(start, end, proof);
+        checkpointTracker.proveTransition(start, end, numPublications, proof);
 
         if (nextPublicationHeaderBytes.length > 0) {
             // This means that the prover is claiming that they have finished all their publications for the period
@@ -333,7 +334,7 @@ contract ProverManager is IProposerFees, IProverManager {
 
         _validateNextPublicationHeader(nextPublicationHeader, end.publicationId + 1, periodEnd);
 
-        checkpointTracker.proveTransition(start, end, proof);
+        checkpointTracker.proveTransition(start, end, numPubs, proof);
 
         // Distribute the funds
         uint256 newProverFees = period.fee * numPubs;

--- a/test/CheckpointTracker.t.sol
+++ b/test/CheckpointTracker.t.sol
@@ -61,10 +61,11 @@ contract CheckpointTrackerTest is Test {
             ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
         ICheckpointTracker.Checkpoint memory end =
             ICheckpointTracker.Checkpoint({publicationId: 3, commitment: keccak256(abi.encode("end"))});
+        uint256 numRelevantPublications = 2;
 
         vm.expectEmit();
         emit ICheckpointTracker.TransitionProven(start, end);
-        tracker.proveTransition(start, end, proof);
+        tracker.proveTransition(start, end, numRelevantPublications, proof);
 
         assertEq(tracker.provenHash(), keccak256(abi.encode(end)));
     }
@@ -74,9 +75,10 @@ contract CheckpointTrackerTest is Test {
             ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
         ICheckpointTracker.Checkpoint memory end =
             ICheckpointTracker.Checkpoint({publicationId: 3, commitment: bytes32(0)});
+        uint256 numRelevantPublications = 2;
 
         vm.expectRevert("Checkpoint commitment cannot be 0");
-        tracker.proveTransition(start, end, proof);
+        tracker.proveTransition(start, end, numRelevantPublications, proof);
     }
 
     function test_proveTransition_RevertWhenStartCheckpointNotLatestProven() public {
@@ -84,9 +86,10 @@ contract CheckpointTrackerTest is Test {
             ICheckpointTracker.Checkpoint({publicationId: 1, commitment: keccak256(abi.encode("wrong"))});
         ICheckpointTracker.Checkpoint memory end =
             ICheckpointTracker.Checkpoint({publicationId: 3, commitment: keccak256(abi.encode("end"))});
+        uint256 numRelevantPublications = 2;
 
         vm.expectRevert("Start checkpoint must be the latest proven checkpoint");
-        tracker.proveTransition(start, end, proof);
+        tracker.proveTransition(start, end, numRelevantPublications, proof);
     }
 
     function test_proveTransition_RevertWhenEndPublicationNotAfterStart() public {
@@ -94,9 +97,12 @@ contract CheckpointTrackerTest is Test {
             ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
         ICheckpointTracker.Checkpoint memory end =
             ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("end"))});
+        // this is nonsensical, but we're testing the publicationId check so I think it makes sense for the other
+        // parameters to match previous tests.
+        uint256 numRelevantPublications = 2;
 
         vm.expectRevert("End publication must be after the last proven publication");
-        tracker.proveTransition(start, end, proof);
+        tracker.proveTransition(start, end, numRelevantPublications, proof);
     }
 
     function createSampleFeed() private {

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -30,7 +30,7 @@ contract ProverManagerTest is Test {
     address evictor = address(0x203);
 
     // Configuration parameters.
-    uint256 constant MIN_UNDERCUT_PERCENTAGE = 500; // 5%
+    uint256 constant MAX_BID_PERCENTAGE = 9500; // 95%
     uint256 constant LIVENESS_WINDOW = 60; // 60 seconds
     uint256 constant SUCCESSION_DELAY = 10;
     uint256 constant EXIT_DELAY = 10;
@@ -50,7 +50,7 @@ contract ProverManagerTest is Test {
 
         // Create the config struct for the constructor
         ProverManager.ProverManagerConfig memory config = ProverManager.ProverManagerConfig({
-            minUndercutPercentage: MIN_UNDERCUT_PERCENTAGE,
+            maxBidPercentage: MAX_BID_PERCENTAGE,
             livenessWindow: LIVENESS_WINDOW,
             successionDelay: SUCCESSION_DELAY,
             exitDelay: EXIT_DELAY,
@@ -171,9 +171,7 @@ contract ProverManagerTest is Test {
         vm.prank(prover1);
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
 
-        // Calculate the minimum required undercut
-        uint256 minUndercut = (INITIAL_FEE * MIN_UNDERCUT_PERCENTAGE) / 10000;
-        uint256 maxAllowedFee = INITIAL_FEE - minUndercut;
+        uint256 maxAllowedFee = INITIAL_FEE * MAX_BID_PERCENTAGE / 10000;
 
         vm.prank(prover1);
         vm.expectEmit();
@@ -206,9 +204,9 @@ contract ProverManagerTest is Test {
         vm.prank(prover1);
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
 
-        // Calculate a fee that's not low enough (only 0.5% lower)
-        uint256 minUndercut = (INITIAL_FEE * MIN_UNDERCUT_PERCENTAGE) / 10000;
-        uint256 insufficientlyReducedFee = INITIAL_FEE - minUndercut + 1;
+        // Calculate a fee that's not low enough
+        uint256 maxFee = INITIAL_FEE * MAX_BID_PERCENTAGE / 10000;
+        uint256 insufficientlyReducedFee = maxFee + 1;
 
         vm.prank(prover1);
         vm.expectRevert("Offered fee not low enough");
@@ -220,7 +218,7 @@ contract ProverManagerTest is Test {
         vm.prank(prover1);
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
 
-        uint256 firstBidFee = INITIAL_FEE - (INITIAL_FEE * MIN_UNDERCUT_PERCENTAGE) / 10000;
+        uint256 firstBidFee = INITIAL_FEE * MAX_BID_PERCENTAGE / 10000;
         vm.prank(prover1);
         proverManager.bid(firstBidFee);
 
@@ -229,7 +227,7 @@ contract ProverManagerTest is Test {
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
 
         // Calculate required fee for second bid
-        uint256 secondBidFee = firstBidFee - (firstBidFee * MIN_UNDERCUT_PERCENTAGE) / 10000;
+        uint256 secondBidFee = firstBidFee * MAX_BID_PERCENTAGE / 10000;
 
         vm.prank(prover2);
         vm.expectEmit();
@@ -258,7 +256,7 @@ contract ProverManagerTest is Test {
         uint256 timestampBefore = block.timestamp;
 
         // Make a bid that will outbid the current prover
-        uint256 bidFee = INITIAL_FEE - (INITIAL_FEE * MIN_UNDERCUT_PERCENTAGE) / 10000;
+        uint256 bidFee = INITIAL_FEE * MAX_BID_PERCENTAGE / 10000;
         vm.prank(prover1);
         proverManager.bid(bidFee);
 
@@ -279,7 +277,7 @@ contract ProverManagerTest is Test {
         vm.prank(prover1);
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
 
-        uint256 firstBidFee = INITIAL_FEE - (INITIAL_FEE * MIN_UNDERCUT_PERCENTAGE) / 10000;
+        uint256 firstBidFee = INITIAL_FEE * MAX_BID_PERCENTAGE / 10000;
         vm.prank(prover1);
         proverManager.bid(firstBidFee);
 
@@ -287,8 +285,8 @@ contract ProverManagerTest is Test {
         vm.prank(prover2);
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
 
-        uint256 minUndercut = (firstBidFee * MIN_UNDERCUT_PERCENTAGE) / 10000;
-        uint256 insufficientlyReducedFee = firstBidFee - minUndercut + 1;
+        uint256 maxFee = firstBidFee * MAX_BID_PERCENTAGE / 10000;
+        uint256 insufficientlyReducedFee = maxFee + 1;
 
         vm.prank(prover2);
         vm.expectRevert("Offered fee not low enough");
@@ -449,7 +447,7 @@ contract ProverManagerTest is Test {
         // Have prover1 bid for next period
         vm.prank(prover1);
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
-        uint256 bidFee = INITIAL_FEE - (INITIAL_FEE * MIN_UNDERCUT_PERCENTAGE) / 10000;
+        uint256 bidFee = INITIAL_FEE * MAX_BID_PERCENTAGE / 10000;
         vm.prank(prover1);
         proverManager.bid(bidFee);
 
@@ -551,7 +549,7 @@ contract ProverManagerTest is Test {
         // Have prover1 bid for next period
         vm.prank(prover1);
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
-        uint256 bidFee = INITIAL_FEE - (INITIAL_FEE * MIN_UNDERCUT_PERCENTAGE) / 10000;
+        uint256 bidFee = INITIAL_FEE * MAX_BID_PERCENTAGE / 10000;
         vm.prank(prover1);
         proverManager.bid(bidFee);
 

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -144,7 +144,7 @@ contract ProverManagerTest is Test {
         assertEq(balanceAfter, DEPOSIT_AMOUNT - INITIAL_FEE, "Publication fee not deducted properly");
     }
 
-    function test_payPublicationFee_AdvacesPeriod() public {
+    function test_payPublicationFee_AdvancesPeriod() public {
         // Deposit funds for proposer.
         vm.prank(proposer);
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
@@ -159,7 +159,7 @@ contract ProverManagerTest is Test {
         // Call payPublicationFee from the inbox and check that the period has been advanced.
         vm.prank(inbox);
         vm.expectEmit();
-        emit ProverManager.NewPeriod(1);
+        emit ProverManager.NewPeriod(2);
         proverManager.payPublicationFee{value: INITIAL_FEE}(proposer, false);
     }
 
@@ -175,11 +175,11 @@ contract ProverManagerTest is Test {
 
         vm.prank(prover1);
         vm.expectEmit();
-        emit ProverManager.ProverOffer(prover1, 1, maxAllowedFee, LIVENESS_BOND);
+        emit ProverManager.ProverOffer(prover1, 2, maxAllowedFee, LIVENESS_BOND);
         proverManager.bid(maxAllowedFee);
 
-        // Check that period 1 has been created
-        ProverManager.Period memory period = proverManager.getPeriod(1);
+        // Check that period 2 has been created
+        ProverManager.Period memory period = proverManager.getPeriod(2);
 
         assertEq(period.prover, prover1, "Bid not recorded for new period");
         assertEq(period.fee, maxAllowedFee, "Offered fee not set correctly");
@@ -231,11 +231,11 @@ contract ProverManagerTest is Test {
 
         vm.prank(prover2);
         vm.expectEmit();
-        emit ProverManager.ProverOffer(prover2, 1, secondBidFee, LIVENESS_BOND);
+        emit ProverManager.ProverOffer(prover2, 2, secondBidFee, LIVENESS_BOND);
         proverManager.bid(secondBidFee);
 
         // Check that period 1 now has prover2 as the prover
-        ProverManager.Period memory period = proverManager.getPeriod(1);
+        ProverManager.Period memory period = proverManager.getPeriod(2);
         assertEq(period.prover, prover2, "Prover2 should now be the next prover");
         assertEq(period.fee, secondBidFee, "Fee should be updated to prover2's bid");
 
@@ -261,7 +261,7 @@ contract ProverManagerTest is Test {
         proverManager.bid(bidFee);
 
         // Check that period 0 now has an end time set
-        ProverManager.Period memory period = proverManager.getPeriod(0);
+        ProverManager.Period memory period = proverManager.getPeriod(1);
         assertEq(
             period.end,
             timestampBefore + SUCCESSION_DELAY,
@@ -301,7 +301,7 @@ contract ProverManagerTest is Test {
 
         uint256 pubId = header.id;
         // Capture current period stake before eviction
-        ProverManager.Period memory periodBefore = proverManager.getPeriod(0);
+        ProverManager.Period memory periodBefore = proverManager.getPeriod(1);
         uint256 stakeBefore = periodBefore.stake;
 
         // Evict the prover
@@ -316,8 +316,8 @@ contract ProverManagerTest is Test {
         );
         proverManager.evictProver(pubId, header, zeroCheckpoint);
 
-        // Verify period 0 is marked as evicted and its stake reduced
-        ProverManager.Period memory periodAfter = proverManager.getPeriod(0);
+        // Verify period 1 is marked as evicted and its stake reduced
+        ProverManager.Period memory periodAfter = proverManager.getPeriod(1);
         assertEq(periodAfter.deadline, block.timestamp + EXIT_DELAY, "Prover should be evicted");
 
         // Calculate expected incentive for the evictor
@@ -401,8 +401,8 @@ contract ProverManagerTest is Test {
         );
         proverManager.exit();
 
-        // Check that period 0 now has an end time and deadline set
-        ProverManager.Period memory period = proverManager.getPeriod(0);
+        // Check that period 1 now has an end time and deadline set
+        ProverManager.Period memory period = proverManager.getPeriod(1);
         assertEq(period.end, block.timestamp + EXIT_DELAY, "Exit did not set period end correctly");
         assertEq(period.deadline, block.timestamp + EXIT_DELAY + PROVING_WINDOW, "Proving deadline not set correctly");
     }

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -629,7 +629,6 @@ contract ProverManagerTest is Test {
             startHeader,
             endHeader,
             2,
-            nextHeader,
             "0x", // any proof
             0
         );
@@ -704,7 +703,6 @@ contract ProverManagerTest is Test {
             startHeader,
             endHeader,
             2,
-            nextHeader,
             "0x", // any proof
             0
         );
@@ -730,7 +728,7 @@ contract ProverManagerTest is Test {
         );
     }
 
-    function test_proveClosedPeriod_RevertWhen_PeriodStillOpen() public {
+    function ignore_proveClosedPeriod_RevertWhen_PeriodStillOpen() public {
         // Setup: Create publications
         IPublicationFeed.PublicationHeader memory startHeader = _insertPublication();
         IPublicationFeed.PublicationHeader memory endHeader = _insertPublication();
@@ -762,7 +760,6 @@ contract ProverManagerTest is Test {
             startHeader,
             endHeader,
             2,
-            nextHeader,
             "0x", // any proof
             0
         );

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -474,7 +474,7 @@ contract ProverManagerTest is Test {
         // // Prove the period
         uint256 proverBalanceBefore = proverManager.balances(initialProver);
 
-        proverManager.proveOpenPeriod(
+        proverManager.prove(
             startCheckpoint,
             endCheckpoint,
             startHeader,
@@ -517,7 +517,7 @@ contract ProverManagerTest is Test {
         // // Prove the period
         uint256 proverBalanceBefore = proverManager.balances(initialProver);
 
-        proverManager.proveOpenPeriod(
+        proverManager.prove(
             startCheckpoint,
             endCheckpoint,
             startHeader,
@@ -574,9 +574,7 @@ contract ProverManagerTest is Test {
 
         // Attempt to prove the period after deadline
         vm.expectRevert("Deadline has passed");
-        proverManager.proveOpenPeriod(
-            startCheckpoint, endCheckpoint, startHeader, endHeader, numRelevantPublications, "0x", 0
-        );
+        proverManager.prove(startCheckpoint, endCheckpoint, startHeader, endHeader, numRelevantPublications, "0x", 0);
     }
 
     /// --------------------------------------------------------------------------
@@ -621,7 +619,7 @@ contract ProverManagerTest is Test {
 
         // Have prover1 prove the closed period
         vm.prank(prover1);
-        proverManager.proveClosedPeriod(
+        proverManager.prove(
             startCheckpoint,
             endCheckpoint,
             startHeader,
@@ -695,7 +693,7 @@ contract ProverManagerTest is Test {
         // Have prover1 prove the closed period
         vm.warp(block.timestamp + PROVING_WINDOW + 1);
         vm.prank(prover1);
-        proverManager.proveClosedPeriod(
+        proverManager.prove(
             startCheckpoint,
             endCheckpoint,
             startHeader,
@@ -752,7 +750,7 @@ contract ProverManagerTest is Test {
         vm.warp(block.timestamp + EXIT_DELAY + 1);
         vm.prank(prover1);
         vm.expectRevert("The period is still open");
-        proverManager.proveClosedPeriod(
+        proverManager.prove(
             startCheckpoint,
             endCheckpoint,
             startHeader,

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -430,7 +430,7 @@ contract ProverManagerTest is Test {
     /// --------------------------------------------------------------------------
     /// proveOpenPeriod()
     /// --------------------------------------------------------------------------
-    function test_proveOpenPeriod_CompletesPeriod() public {
+    function ignore_proveOpenPeriod_CompletesPeriod() public {
         // Setup: Create publications and pay for the fees
         IPublicationFeed.PublicationHeader memory startHeader = _insertPublication();
         IPublicationFeed.PublicationHeader memory endHeader = _insertPublication();
@@ -482,7 +482,7 @@ contract ProverManagerTest is Test {
             startHeader,
             endHeader,
             numRelevantPublications,
-            nextHeaderBytes,
+            // nextHeaderBytes,
             "0x", // any proof
             0 // provingPeriodId. Hardcode the value to avoid stack-too-deep error
         );
@@ -525,7 +525,6 @@ contract ProverManagerTest is Test {
             startHeader,
             endHeader,
             numRelevantPublications,
-            "", // empty next publication header
             "0x", // any proof
             provingPeriodId
         );
@@ -540,7 +539,7 @@ contract ProverManagerTest is Test {
         assertEq(proverBalanceAfter, proverBalanceBefore, "Prover should not receive any funds yet");
     }
 
-    function test_proveOpenPeriod_RevertWhen_DeadlinePassed() public {
+    function ignore_proveOpenPeriod_RevertWhen_DeadlinePassed() public {
         // Setup: Create publications and advance to period 1
         IPublicationFeed.PublicationHeader memory startHeader = _insertPublication();
         IPublicationFeed.PublicationHeader memory endHeader = _insertPublication();
@@ -578,7 +577,7 @@ contract ProverManagerTest is Test {
         // Attempt to prove the period after deadline
         vm.expectRevert("Deadline has passed");
         proverManager.proveOpenPeriod(
-            startCheckpoint, endCheckpoint, startHeader, endHeader, numRelevantPublications, "", "0x", 0
+            startCheckpoint, endCheckpoint, startHeader, endHeader, numRelevantPublications, "0x", 0
         );
     }
 

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -618,11 +618,6 @@ contract ProverManagerTest is Test {
         vm.warp(block.timestamp + EXIT_DELAY + 1);
         IPublicationFeed.PublicationHeader memory nextHeader = _insertPublication();
 
-        // Create an array of publication headers to prove
-        IPublicationFeed.PublicationHeader[] memory pubHeaders = new IPublicationFeed.PublicationHeader[](2);
-        pubHeaders[0] = startHeader;
-        pubHeaders[1] = endHeader;
-
         // Capture balances before proving
         uint256 prover1BalanceBefore = proverManager.balances(prover1);
         uint256 initialProverBalanceBefore = proverManager.balances(initialProver);
@@ -632,7 +627,9 @@ contract ProverManagerTest is Test {
         proverManager.proveClosedPeriod(
             startCheckpoint,
             endCheckpoint,
-            pubHeaders,
+            startHeader,
+            endHeader,
+            2,
             nextHeader,
             "0x", // any proof
             0
@@ -695,11 +692,6 @@ contract ProverManagerTest is Test {
         vm.warp(block.timestamp + EXIT_DELAY + 1);
         IPublicationFeed.PublicationHeader memory nextHeader = _insertPublication();
 
-        // Create an array of publication headers to prove
-        IPublicationFeed.PublicationHeader[] memory pubHeaders = new IPublicationFeed.PublicationHeader[](2);
-        pubHeaders[0] = startHeader;
-        pubHeaders[1] = endHeader;
-
         // Capture balances before proving
         uint256 prover1BalanceBefore = proverManager.balances(prover1);
         uint256 initialProverBalanceBefore = proverManager.balances(initialProver);
@@ -710,7 +702,9 @@ contract ProverManagerTest is Test {
         proverManager.proveClosedPeriod(
             startCheckpoint,
             endCheckpoint,
-            pubHeaders,
+            startHeader,
+            endHeader,
+            2,
             nextHeader,
             "0x", // any proof
             0
@@ -755,11 +749,6 @@ contract ProverManagerTest is Test {
         // Create a next publication header
         IPublicationFeed.PublicationHeader memory nextHeader = _insertPublication();
 
-        // Create an array of publication headers to prove
-        IPublicationFeed.PublicationHeader[] memory pubHeaders = new IPublicationFeed.PublicationHeader[](2);
-        pubHeaders[0] = startHeader;
-        pubHeaders[1] = endHeader;
-
         // Exit as the initial prover to set period end
         vm.prank(initialProver);
         proverManager.exit();
@@ -771,7 +760,9 @@ contract ProverManagerTest is Test {
         proverManager.proveClosedPeriod(
             startCheckpoint,
             endCheckpoint,
-            pubHeaders,
+            startHeader,
+            endHeader,
+            2,
             nextHeader,
             "0x", // any proof
             0

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -186,7 +186,6 @@ contract ProverManagerTest is Test {
         assertEq(period.prover, prover1, "Bid not recorded for new period");
         assertEq(period.fee, maxAllowedFee, "Offered fee not set correctly");
         assertEq(period.stake, LIVENESS_BOND, "Liveness bond not locked");
-        assertEq(period.accumulatedFees, 0, "Accumulated fees should be zero");
         assertEq(period.end, 0, "Period end should be zero until active");
         assertEq(period.deadline, 0, "Deadline should be zero until active");
 
@@ -496,7 +495,7 @@ contract ProverManagerTest is Test {
         );
     }
 
-    function test_proveOpenPeriod_InsidePeriod() public {
+    function ignore_proveOpenPeriod_InsidePeriod() public {
         // Setup: Create publications and pay for the fees
         uint256 provingPeriodId = 0;
         IPublicationFeed.PublicationHeader memory startHeader = _insertPublication();
@@ -533,9 +532,10 @@ contract ProverManagerTest is Test {
 
         uint256 proverBalanceAfter = proverManager.balances(initialProver);
         ProverManager.Period memory periodAfter = proverManager.getPeriod(provingPeriodId);
-        assertEq(
-            periodAfter.accumulatedFees, INITIAL_FEE * 2, "Accumulated fees should be the sum of the two publications"
-        );
+        // assertEq(
+        //     periodAfter.accumulatedFees, INITIAL_FEE * 2, "Accumulated fees should be the sum of the two
+        // publications"
+        // );
         assertEq(periodAfter.stake, LIVENESS_BOND, "Stake should be the liveness bond");
         assertEq(proverBalanceAfter, proverBalanceBefore, "Prover should not receive any funds yet");
     }
@@ -585,7 +585,7 @@ contract ProverManagerTest is Test {
     /// --------------------------------------------------------------------------
     /// proveClosedPeriod()
     /// --------------------------------------------------------------------------
-    function test_proveClosedPeriod_AfterEviction() public {
+    function ignore_proveClosedPeriod_AfterEviction() public {
         // Setup: Create publications and pay for the fees
         IPublicationFeed.PublicationHeader memory startHeader = _insertPublication();
         IPublicationFeed.PublicationHeader memory endHeader = _insertPublication();
@@ -658,7 +658,7 @@ contract ProverManagerTest is Test {
         );
     }
 
-    function test_proveClosedPeriod_AfterDeadlinePassed() public {
+    function ignore_proveClosedPeriod_AfterDeadlinePassed() public {
         // Setup: Create publications and pay for the fees
         IPublicationFeed.PublicationHeader memory startHeader = _insertPublication();
         IPublicationFeed.PublicationHeader memory endHeader = _insertPublication();

--- a/test/mocks/MockCheckpointTracker.sol
+++ b/test/mocks/MockCheckpointTracker.sol
@@ -13,7 +13,12 @@ contract MockCheckpointTracker is ICheckpointTracker {
     }
 
     /// @notice Do nothing. All checkpoints and proofs are accepted.
-    function proveTransition(Checkpoint calldata start, Checkpoint calldata end, bytes calldata proof) external {}
+    function proveTransition(
+        Checkpoint calldata start,
+        Checkpoint calldata end,
+        uint256 numPublications,
+        bytes calldata proof
+    ) external {}
 
     /// @notice Helper to set the proven hash for easier testing
     /// @param checkpoint the checkpoint to set as proven, that will be hashed and stored as the proven hash

--- a/test/mocks/NullVerifier.sol
+++ b/test/mocks/NullVerifier.sol
@@ -10,6 +10,7 @@ contract NullVerifier is IVerifier {
         bytes32, /* endPublicationHash */
         bytes32, /* startCheckPoint */
         bytes32, /* endCheckPoint */
+        uint256, /* numPublications */
         bytes calldata /* proof */
     ) external {}
 }


### PR DESCRIPTION
To implement proveClosedPeriod, let's require the prover to check the publication count.
Note: the rest of the logic also applies if we can compute the publication count from the
publication IDs as well (i.e. if we do not have a shared feed).

With this addition, I think we can simplify the ProverManager, by paying for proofs as
they are submitted. This PR is my attempt at that.

Some things to note:

- the rationale for each change is explained in the commit message
- I identified and fixed some actual bugs (so if we do not merge this, we should still fix the corresponding bugs)
- I ignored some of the tests because it will be easier to rewrite them once the change is complete
- I ran out of time. I thought it make sense to push the PR anyway so you can see the idea.

