### PR TITLE
Price delayed publications

### DIFF
--- a/.github/workflows/gas.yml
+++ b/.github/workflows/gas.yml
@@ -1,0 +1,57 @@
+name: Report gas diff
+
+on:
+  push:
+  pull_request:
+    paths:
+      - src/**
+      - test/**
+      - foundry.toml
+      - .github/workflows/gas.yml
+  workflow_dispatch:
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  compare_gas_reports:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Show Forge version
+        run: |
+          forge --version
+
+      # Do not count negative and fuzz tests toward gas calculations since they can add noise
+      # (https://book.getfoundry.sh/guides/best-practices?highlight=best%20pr#general-test-guidance)
+      - name: Run Forge tests
+        run: |
+          forge test --no-match-test "(RevertWhen|testFuzz)" --gas-report --color never | tee gasreport.ansi
+        id: test
+
+      - name: Compare gas reports
+        uses: Rubilmax/foundry-gas-diff@v3
+        with:
+          summaryQuantile: 0.9 # only display the 10% most significant gas diffs in the summary (defaults to 20%)
+          sortCriteria: avg,max # sort diff rows by criteria
+          sortOrders: desc,asc
+          base: ${{ github.base_ref }}
+        id: gas_diff
+
+      - name: Add gas diff to sticky comment
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          # delete the comment in case changes no longer impact gas costs
+          delete: ${{ !steps.gas_diff.outputs.markdown }}
+          message: ${{ steps.gas_diff.outputs.markdown }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ env:
 
 jobs:
   check:
-    strategy:
-      fail-fast: true
-
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +20,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Show Forge version
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ docs/
 
 # Dotenv file
 .env
+
+# Added by cargo
+/target

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -56,7 +56,7 @@ This guide is not intended to be comprehensive, but rather to provide a starting
 
     ```solidity
     interface IMyContract {
-        // These event and struct are part of the interface
+        // This event and struct are part of the interface
         event Published();
         struct MyStruct {
             uint256 value;

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -104,7 +104,7 @@ This guide is not intended to be comprehensive, but rather to provide a starting
     error InsufficientBalance(uint256 balance, uint256 required);
 
     function withdraw(uint256 amount) external {
-        if (amount > balance) revert InsufficientBalance(balance, amount);
+        require(amount <= balance, InsufficientBalance(balance, amount));
         balance -= amount;
     }
     ```

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -29,7 +29,7 @@ This guide is not intended to be comprehensive, but rather to provide a starting
     event Published();
     ```
 
-1. Constructor parameters, when they overshade a state variable, should be prefixed with an underscore.
+1. Constructor parameters, when they shadow a state variable, should be prefixed with an underscore.
 
     ```solidity
     constructor(uint256 _totalSupply) {
@@ -37,7 +37,7 @@ This guide is not intended to be comprehensive, but rather to provide a starting
     }
     ```
 
-1. Local variables or function parameters when they overshade a state variable should be suffixed with an underscore.
+1. Local variables or function parameters when they shadow a state variable should be suffixed with an underscore.
 
     ```solidity
     uint256 public totalSupply;

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -53,6 +53,7 @@ This guide is not intended to be comprehensive, but rather to provide a starting
 1. Events and structs when part of the contract's public API should be defined in the contract interface.
 
     If they are an implementation detail, or emitted by a specific implementation, they should instead be defined in the contract itself, and not part of the interface.
+
     ```solidity
     interface IMyContract {
         // These event and struct are part of the interface
@@ -116,6 +117,17 @@ This guide is not intended to be comprehensive, but rather to provide a starting
     function withdraw(uint256 amount) external {
         require(amount <= balance, "Insufficient balance");
         balance -= amount;
+    }
+    ```
+
+1. Constructors should have natspec, but it can be simpler than other functions. If the constructor simply assigns values to state variables, specifying the parameters is sufficient.
+
+    ```solidity
+    /// @param _inclusionDelay The delay before next set of inclusions can be processed.
+    /// @param _blobRefRegistry The address of the blob reference registry.
+    constructor(uint256 _inclusionDelay, address _blobRefRegistry) {
+        inclusionDelay = _inclusionDelay;
+        blobRefRegistry = IBlobRefRegistry(_blobRefRegistry);
     }
     ```
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 evm_version = "cancun"
+always_use_create_2_factory = true # Use Foundry's create2 factory in tests(https://github.com/foundry-rs/foundry/pull/6656)
 
 [fmt]
 sort_imports = true

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,8 @@ libs = ["lib"]
 evm_version = "cancun"
 always_use_create_2_factory = true # Use Foundry's create2 factory in tests(https://github.com/foundry-rs/foundry/pull/6656)
 
+gas_reports_ignore = ["MockDelayedInclusionStore", "MockCheckpointTracker", ""]
+
 [fmt]
 sort_imports = true
 wrap_comments = true

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,8 +7,6 @@ always_use_create_2_factory = true # Use Foundry's create2 factory in tests(http
 
 gas_reports_ignore = ["MockDelayedInclusionStore", "MockCheckpointTracker", ""]
 
-gas_reports_ignore = ["MockDelayedInclusionStore", "MockCheckpointTracker", ""]
-
 [fmt]
 sort_imports = true
 wrap_comments = true

--- a/src/libs/LibPercentage.sol
+++ b/src/libs/LibPercentage.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+library LibPercentage {
+    using SafeCast for uint256;
+
+    // COMMON PRECISION AMOUNTS (https://muens.io/solidity-percentages)
+    uint256 constant BASIS_POINTS = 10_000;
+    uint256 constant PERCENT = 100;
+
+    /// @dev Calculates the percentage of a given value scaling by `precision` to limit rounding loss
+    /// @param value The number to scale
+    /// @param percentage The percentage expressed in `precision` units.
+    /// @param precision The precision of `percentage` (e.g. percentage 5000 with BASIS_POINTS precision is 50%).
+    /// @return _ The scaled value
+    function scaleBy(uint256 value, uint16 percentage, uint256 precision) internal pure returns (uint96) {
+        return (value * percentage / precision).toUint96();
+    }
+
+    /// @dev Calculates the percentage (represented in basis points) of a given value
+    /// @param value The number to scale
+    /// @param percentage The percentage expressed in basis points
+    /// @return _ The scaled value
+    function scaleByBPS(uint256 value, uint16 percentage) internal pure returns (uint96) {
+        return scaleBy(value, percentage, BASIS_POINTS);
+    }
+
+    /// @dev Calculates the percentage of a given value
+    /// @param value The number to scale
+    /// @param percentage The percentage to single-percentage precision (e.g. percentage 50 is 50%)
+    /// @return _ The scaled value
+    function scaleByPercentage(uint256 value, uint16 percentage) internal pure returns (uint96) {
+        return scaleBy(value, percentage, BASIS_POINTS);
+    }
+}

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -150,7 +150,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
 
         // Reward the evictor and slash the prover
         // Casting this directly is safe since the resulting number is smaller than the original value
-        uint96 evictorIncentive = uint96(_calculatePercentage(period.stake, _evictorIncentivePercentage()));
+        uint96 evictorIncentive = _calculatePercentage(period.stake, _evictorIncentivePercentage()).toUint96();
         _balances[msg.sender] += evictorIncentive;
         period.stake -= evictorIncentive;
 
@@ -232,7 +232,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
 
         uint96 stake = period.stake;
         _balances[period.prover] +=
-            period.pastDeadline ? uint96(_calculatePercentage(stake, _rewardPercentage())) : stake;
+            period.pastDeadline ? _calculatePercentage(stake, _rewardPercentage()).toUint96() : stake;
         period.stake = 0;
     }
 
@@ -375,7 +375,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         private
         returns (uint40 end, uint40 deadline)
     {
-        end = uint40(block.timestamp) + endDelay;
+        end = block.timestamp.toUint40() + endDelay;
         deadline = end + provingWindow_;
         period.end = end;
         period.deadline = deadline;

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -19,6 +19,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         uint96 fee;
         // the percentage (in bps) of the fee that is charged for delayed publications.
         uint16 delayedFeePercentage;
+        // the timestamp of the end of the period. Default to zero while the period is open.
         uint40 end;
         // the time by which the prover needs to submit a proof
         uint40 deadline;

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -94,8 +94,6 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         // Deduct fee from proposer's balance
         uint96 fee = _periods[periodId].fee;
         if (isDelayed) {
-            // This is extremely unlikely to overflow, but we still do the check to be safe since the
-            // `delayedFeePercentage` is >100%
             fee = _calculatePercentage(fee, _periods[periodId].delayedFeePercentage).toUint96();
         }
         _balances[proposer] -= fee;
@@ -149,7 +147,6 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         (uint40 end,) = _closePeriod(period, _exitDelay(), 0);
 
         // Reward the evictor and slash the prover
-        // Casting this directly is safe since the resulting number is smaller than the original value
         uint96 evictorIncentive = _calculatePercentage(period.stake, _evictorIncentivePercentage()).toUint96();
         _balances[msg.sender] += evictorIncentive;
         period.stake -= evictorIncentive;
@@ -249,8 +246,6 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
 
         Period storage period = _periods[currentPeriod];
         fee = period.fee;
-        // This is extremely unlikely to overflow, but we still do the check to be safe since the
-        // `delayedFeePercentage` is >100%
         delayedFee = _calculatePercentage(fee, period.delayedFeePercentage).toUint96();
     }
 

--- a/src/protocol/CheckpointTracker.sol
+++ b/src/protocol/CheckpointTracker.sol
@@ -35,8 +35,9 @@ contract CheckpointTracker is ICheckpointTracker {
     }
 
     /// @inheritdoc ICheckpointTracker
+    /// @dev This function does not use the `start` checkpoint since we don't support parallel transitions.
     function proveTransition(
-        Checkpoint calldata start,
+        Checkpoint calldata,
         Checkpoint calldata end,
         uint256 numPublications,
         uint256 numDelayedPublications,
@@ -47,26 +48,18 @@ contract CheckpointTracker is ICheckpointTracker {
         );
 
         require(end.commitment != 0, "Checkpoint commitment cannot be 0");
-
-        require(
-            start.publicationId == _provenCheckpoint.publicationId && start.commitment == _provenCheckpoint.commitment,
-            "Start checkpoint must be the latest proven checkpoint"
-        );
-
-        require(start.publicationId < end.publicationId, "End publication must be after the last proven publication");
         require(
             numDelayedPublications <= numPublications,
             "Number of delayed publications cannot be greater than the total number of publications"
         );
-
-        bytes32 startPublicationHash = publicationFeed.getPublicationHash(start.publicationId);
+        bytes32 startPublicationHash = publicationFeed.getPublicationHash(_provenCheckpoint.publicationId);
         bytes32 endPublicationHash = publicationFeed.getPublicationHash(end.publicationId);
         require(endPublicationHash != 0, "End publication does not exist");
 
         verifier.verifyProof(
             startPublicationHash,
             endPublicationHash,
-            start.commitment,
+            _provenCheckpoint.commitment,
             end.commitment,
             numPublications,
             numDelayedPublications,

--- a/src/protocol/CheckpointTracker.sol
+++ b/src/protocol/CheckpointTracker.sol
@@ -54,6 +54,10 @@ contract CheckpointTracker is ICheckpointTracker {
         );
 
         require(start.publicationId < end.publicationId, "End publication must be after the last proven publication");
+        require(
+            numDelayedPublications <= numPublications,
+            "Number of delayed publications cannot be greater than the total number of publications"
+        );
 
         bytes32 startPublicationHash = publicationFeed.getPublicationHash(start.publicationId);
         bytes32 endPublicationHash = publicationFeed.getPublicationHash(end.publicationId);

--- a/src/protocol/CheckpointTracker.sol
+++ b/src/protocol/CheckpointTracker.sol
@@ -39,6 +39,7 @@ contract CheckpointTracker is ICheckpointTracker {
         Checkpoint calldata start,
         Checkpoint calldata end,
         uint256 numPublications,
+        uint256 numDelayedPublications,
         bytes calldata proof
     ) external {
         require(
@@ -59,7 +60,13 @@ contract CheckpointTracker is ICheckpointTracker {
         require(endPublicationHash != 0, "End publication does not exist");
 
         verifier.verifyProof(
-            startPublicationHash, endPublicationHash, start.commitment, end.commitment, numPublications, proof
+            startPublicationHash,
+            endPublicationHash,
+            start.commitment,
+            end.commitment,
+            numPublications,
+            numDelayedPublications,
+            proof
         );
 
         _provenCheckpoint = end;

--- a/src/protocol/ERC20ProverManager.sol
+++ b/src/protocol/ERC20ProverManager.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.8.28;
+
+import {BaseProverManager} from "./BaseProverManager.sol";
+import {IERC20Depositor} from "./IProverManager.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title ERC20ProverManager
+/// @notice Implementation of the `BaseProverManager` contract that uses an ERC20 decided by the deployer of this
+/// contract for bids, stake and paying for publication fees.
+/// @dev This contract expects the `_initialProver` to have already approved this address to spend at least the initial
+/// liveness bond. This amount of tokens will be transferred from the `_initialProver` on the constructor at deployment.
+abstract contract ERC20ProverManager is BaseProverManager, IERC20Depositor {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable token;
+
+    constructor(
+        address _inbox,
+        address _checkpointTracker,
+        address _publicationFeed,
+        address _initialProver,
+        uint96 _initialFee,
+        address _token,
+        uint256 _initialDeposit
+    ) BaseProverManager(_inbox, _checkpointTracker, _publicationFeed, _initialProver, _initialFee, _initialDeposit) {
+        require(_token != address(0), "Token address cannot be 0");
+        require(
+            _initialDeposit >= _livenessBond(), "Initial deposit must be greater than or equal to the liveness bond"
+        );
+
+        token = IERC20(_token);
+
+        // Deposit the amount of funds needed for the liveness bond from the `_initialProver`
+        token.safeTransferFrom(_initialProver, address(this), _initialDeposit);
+    }
+
+    /// @inheritdoc IERC20Depositor
+    /// @dev The deposit can be used both for opting in as a prover or proposer
+    function deposit(uint256 amount) external {
+        _deposit(msg.sender, amount);
+        token.safeTransferFrom(msg.sender, address(this), amount);
+    }
+
+    function _transferOut(address to, uint256 amount) internal override {
+        token.safeTransfer(to, amount);
+    }
+}

--- a/src/protocol/ETHProverManager.sol
+++ b/src/protocol/ETHProverManager.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BaseProverManager} from "./BaseProverManager.sol";
+import {IETHDepositor} from "./IProverManager.sol";
+
+/// @title ETHProverManager
+/// @notice Implementation of the `BaseProverManager` contract that uses ETH for bids, stake and paying for publication
+/// fees.
+abstract contract ETHProverManager is BaseProverManager, IETHDepositor {
+    constructor(
+        address _inbox,
+        address _checkpointTracker,
+        address _publicationFeed,
+        address _initialProver,
+        uint96 _initialFee
+    ) payable BaseProverManager(_inbox, _checkpointTracker, _publicationFeed, _initialProver, _initialFee, msg.value) {
+        require(
+            msg.value >= _livenessBond(),
+            "The amount of ETH deposited must be greater than or equal to the livenessBond"
+        );
+    }
+
+    /// @notice Receive ETH transfers and deposit them to the sender's balance
+    /// @dev This allows direct ETH transfers to the contract to be credited as deposits
+    receive() external payable {
+        _deposit(msg.sender, msg.value);
+    }
+
+    /// @inheritdoc IETHDepositor
+    /// @dev The deposit can be used both for opting in as a prover or proposer
+    function deposit() external payable {
+        _deposit(msg.sender, msg.value);
+    }
+
+    function _transferOut(address to, uint256 amount) internal override {
+        bool ok;
+        // Using assembly to avoid memory allocation costs; only the call's success matters to ensure funds are sent.
+        assembly ("memory-safe") {
+            ok := call(gas(), to, amount, 0, 0, 0, 0)
+        }
+        require(ok, "Withdraw failed");
+    }
+}

--- a/src/protocol/ICheckpointTracker.sol
+++ b/src/protocol/ICheckpointTracker.sol
@@ -20,11 +20,13 @@ interface ICheckpointTracker {
     /// @param numPublications The number of publications that need to be processed between the two checkpoints.
     /// Note that this is not necessarily (end.publicationId - start.publicationId) because there could be irrelevant
     /// publications.
+    /// @param numDelayedPublications The number of delayed publications from the total of `numPublications`
     /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
     function proveTransition(
         Checkpoint calldata start,
         Checkpoint calldata end,
         uint256 numPublications,
+        uint256 numDelayedPublications,
         bytes calldata proof
     ) external;
 }

--- a/src/protocol/IProposerFees.sol
+++ b/src/protocol/IProposerFees.sol
@@ -21,5 +21,5 @@ interface IProposerFees {
     /// @notice Returns the current fees for a period
     /// @return fee The fee for a regular publication
     /// @return delayedFee The fee for a delayed publication
-    function getCurrentFees() external view returns (uint256 fee, uint256 delayedFee);
+    function getCurrentFees() external view returns (uint96 fee, uint96 delayedFee);
 }

--- a/src/protocol/IProposerFees.sol
+++ b/src/protocol/IProposerFees.sol
@@ -2,6 +2,16 @@
 pragma solidity ^0.8.28;
 
 interface IProposerFees {
+    /// @notice Emitted when a user deposits into the contract
+    /// @param user The address that made the deposit
+    /// @param amount The amount that the user deposited
+    event Deposit(address indexed user, uint256 amount);
+
+    /// @notice Emitted when a user withdraws from the contract
+    /// @param user The address that made the withdrawal
+    /// @param amount The amount that the user withdrew
+    event Withdrawal(address indexed user, uint256 amount);
+
     /// @notice Proposers have to pay a fee for each publication they want to get proven. This should be called only by
     /// the Inbox contract.
     /// @param proposer The address of the proposer

--- a/src/protocol/IProposerFees.sol
+++ b/src/protocol/IProposerFees.sol
@@ -6,7 +6,7 @@ interface IProposerFees {
     /// the Inbox contract.
     /// @param proposer The address of the proposer
     /// @param isDelayed Whether the publication is a delayed publication
-    function payPublicationFee(address proposer, bool isDelayed) external payable;
+    function payPublicationFee(address proposer, bool isDelayed) external;
 
     /// @notice Returns the current fees for a period
     /// @return fee The fee for a regular publication

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -31,7 +31,7 @@ interface IProverManager {
 
     /// @notice Bid to become the prover for the next period
     /// @param offeredFee The fee you are willing to charge for proving each publication
-    function bid(uint256 offeredFee) external;
+    function bid(uint96 offeredFee) external;
 
     /// @notice The current prover can signal exit to eventually pull out their liveness bond.
     function exit() external;
@@ -46,7 +46,7 @@ interface IProverManager {
     /// This function allows anyone to start a new period with a new fee. Note that the new prover will still need to
     // ensure the previous publications are proven before proving their own. Nevertheless, we start a new period so
     // they cannot be evicted based on publications that occurred before they agreed to prove
-    function claimProvingVacancy(uint256 fee) external;
+    function claimProvingVacancy(uint96 fee) external;
 
     /// @notice Evicts a prover that has been inactive, marking the prover for slashing
     /// @param publicationHeader The publication header that the caller is claiming is too old and hasn't been proven
@@ -84,4 +84,14 @@ interface IProverManager {
     /// @dev We assume there will always be a suitable proven publication.
     function finalizePastPeriod(uint256 periodId, IPublicationFeed.PublicationHeader calldata provenPublication)
         external;
+}
+
+interface IERC20Depositor {
+    /// @notice Deposit tokens into the contract.
+    function deposit(uint256 amount) external;
+}
+
+interface IETHDepositor {
+    /// @notice Deposit ETH into the contract.
+    function deposit() external payable;
 }

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -7,10 +7,10 @@ import {IPublicationFeed} from "./IPublicationFeed.sol";
 interface IProverManager {
     /// @notice Emitted when a prover bids to prove a period
     /// @param prover The address of the prover that made the bid
-    /// @param period The period that the prover is bidding to prove
+    /// @param periodId The period that the prover is bidding to prove
     /// @param fee The fee that the prover is willing to charge for proving each publication
     /// @param stake The stake that the prover is going to put as stake for the period
-    event ProverOffer(address indexed prover, uint256 period, uint256 fee, uint256 stake);
+    event ProverOffer(address indexed prover, uint256 periodId, uint256 fee, uint256 stake);
 
     /// @notice Emitted when a prover is evicted from the prover role
     /// @param prover The address of the prover that was evicted
@@ -26,8 +26,8 @@ interface IProverManager {
     event ProverExited(address indexed prover, uint256 periodEnd, uint256 provingDeadline);
 
     /// @notice Emitted when a new period starts
-    /// @param period The id of the new period
-    event NewPeriod(uint256 period);
+    /// @param periodId The id of the new period
+    event NewPeriod(uint256 periodId);
 
     /// @notice Bid to become the prover for the next period
     /// @param offeredFee The fee you are willing to charge for proving each publication

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -39,6 +39,7 @@ interface IProverManager {
     /// @param lastPub The last publication header in the transition
     /// @param numPublications The number of publications to process. This is not implied by the start/end publication
     /// ids because the `PublicationFeed` is shared and may contain publications not relevant for this rollup
+    /// @param numDelayedPublications The number of delayed publications from the total of `numPublications`
     /// @param proof Arbitrary data passed to the `verifier` contract to confirm the transition validity
     /// @param periodId The id of the period for which the proof is submitted
     function prove(
@@ -47,6 +48,7 @@ interface IProverManager {
         IPublicationFeed.PublicationHeader calldata firstPub,
         IPublicationFeed.PublicationHeader calldata lastPub,
         uint256 numPublications,
+        uint256 numDelayedPublications,
         bytes calldata proof,
         uint256 periodId
     ) external;

--- a/src/protocol/IProverManager.sol
+++ b/src/protocol/IProverManager.sol
@@ -5,6 +5,30 @@ import {ICheckpointTracker} from "./ICheckpointTracker.sol";
 import {IPublicationFeed} from "./IPublicationFeed.sol";
 
 interface IProverManager {
+    /// @notice Emitted when a prover bids to prove a period
+    /// @param prover The address of the prover that made the bid
+    /// @param period The period that the prover is bidding to prove
+    /// @param fee The fee that the prover is willing to charge for proving each publication
+    /// @param stake The stake that the prover is going to put as stake for the period
+    event ProverOffer(address indexed prover, uint256 period, uint256 fee, uint256 stake);
+
+    /// @notice Emitted when a prover is evicted from the prover role
+    /// @param prover The address of the prover that was evicted
+    /// @param evictor The address that evicted the prover
+    /// @param periodEnd The end of the period that the prover was evicted from
+    /// @param livenessBond The liveness bond that the prover had originally put up
+    event ProverEvicted(address indexed prover, address indexed evictor, uint256 periodEnd, uint256 livenessBond);
+
+    /// @notice Emitted when a prover exits the prover role
+    /// @param prover The address of the prover that exited
+    /// @param periodEnd The end of the period that the prover exited from
+    /// @param provingDeadline The deadline for the prover to prove the period
+    event ProverExited(address indexed prover, uint256 periodEnd, uint256 provingDeadline);
+
+    /// @notice Emitted when a new period starts
+    /// @param period The id of the new period
+    event NewPeriod(uint256 period);
+
     /// @notice Bid to become the prover for the next period
     /// @param offeredFee The fee you are willing to charge for proving each publication
     function bid(uint256 offeredFee) external;

--- a/src/protocol/IVerifier.sol
+++ b/src/protocol/IVerifier.sol
@@ -9,6 +9,7 @@ interface IVerifier {
         bytes32 startCheckPoint,
         bytes32 endCheckPoint,
         uint256 numPublications,
+        uint256 numDelayedPublications,
         bytes calldata proof
     ) external;
 }

--- a/src/protocol/taiko_alethia/DelayedInclusionStore.sol
+++ b/src/protocol/taiko_alethia/DelayedInclusionStore.sol
@@ -34,6 +34,7 @@ abstract contract DelayedInclusionStore is IDelayedInclusionStore {
     IBlobRefRegistry public immutable blobRefRegistry;
 
     /// @param _inclusionDelay The delay before next set of inclusions can be processed.
+    /// @param _blobRefRegistry The address of the blob reference registry.
     constructor(uint256 _inclusionDelay, address _blobRefRegistry) {
         inclusionDelay = _inclusionDelay;
         blobRefRegistry = IBlobRefRegistry(_blobRefRegistry);

--- a/src/protocol/taiko_alethia/ProverManager.sol
+++ b/src/protocol/taiko_alethia/ProverManager.sol
@@ -131,13 +131,8 @@ contract ProverManager is IProposerFees, IProverManager {
 
     /// @inheritdoc IProposerFees
     /// @dev This function advances to the next period if the current period has ended.
-    function payPublicationFee(address proposer, bool isDelayed) external payable {
+    function payPublicationFee(address proposer, bool isDelayed) external {
         require(msg.sender == inbox, "Only the Inbox contract can call this function");
-
-        // Accept additional deposit if sent
-        if (msg.value > 0) {
-            _deposit(proposer, msg.value);
-        }
 
         uint256 periodId = currentPeriodId;
 

--- a/src/protocol/taiko_alethia/ProverManager.sol
+++ b/src/protocol/taiko_alethia/ProverManager.sol
@@ -11,12 +11,16 @@ contract ProverManager is IProposerFees, IProverManager {
     // together.
     struct Period {
         address prover;
-        uint256 stake; // stake the prover locked to register
-        uint256 fee; // per-publication fee (in wei)
-        uint16 delayedFeePercentage; // the percentage (in bps) of the fee that is charged for delayed publications.
-        uint256 end; // the end of the period(this may happen because the prover exits, is evicted or outbid)
-        uint256 deadline; // the time by which the prover needs to submit a proof
-        bool pastDeadline; // whether the proof came after the deadline
+        uint256 stake;
+        // the fee that the prover is willing to charge for proving each publication
+        uint256 fee;
+        // the percentage (in bps) of the fee that is charged for delayed publications.
+        uint16 delayedFeePercentage;
+        uint256 end;
+        // the time by which the prover needs to submit a proof
+        uint256 deadline;
+        // whether the proof came after the deadline
+        bool pastDeadline;
     }
 
     /// @dev This struct is necessary to pass it to the constructor and avoid stack too deep errors
@@ -74,13 +78,14 @@ contract ProverManager is IProposerFees, IProverManager {
     /// @dev Periods represent proving windows
     mapping(uint256 periodId => Period) private _periods;
 
-    event Deposit(address indexed user, uint256 amount);
-    event Withdrawal(address indexed user, uint256 amount);
-    event ProverOffer(address indexed proposer, uint256 period, uint256 fee, uint256 stake);
-    event ProverEvicted(address indexed prover, address indexed evictor, uint256 periodEnd, uint256 livenessBond);
-    event ProverExited(address indexed prover, uint256 periodEnd, uint256 provingDeadline);
-    event NewPeriod(uint256 period);
-
+    /// @dev Initializes the contract state and deposits the initial prover's liveness bond.
+    /// The constructor also calls `_claimProvingVacancy`. Publications will actually start in period 1.
+    /// @param _inbox The address of the inbox contract
+    /// @param _checkpointTracker The address of the checkpoint tracker contract
+    /// @param _publicationFeed The address of the publication feed contract
+    /// @param _initialProver The address that will be designated as the initial prover
+    /// @param _initialFee The fee for the initial period
+    /// @param _config The configuration struct for the contract
     constructor(
         address _inbox,
         address _checkpointTracker,
@@ -159,27 +164,27 @@ contract ProverManager is IProposerFees, IProverManager {
     /// period is active or not.
     /// An active period is one that doesn't have an `end` timestamp yet.
     function bid(uint256 offeredFee) external {
-        uint256 currentPeriod = currentPeriodId;
-        Period storage _currentPeriod = _periods[currentPeriod];
-        Period storage _nextPeriod = _periods[currentPeriod + 1];
-        if (_currentPeriod.end == 0) {
-            _ensureSufficientUnderbid(_currentPeriod.fee, offeredFee);
-            _closePeriod(_currentPeriod, successionDelay, provingWindow);
+        uint256 currentPeriodId_ = currentPeriodId;
+        Period storage currentPeriod = _periods[currentPeriodId_];
+        Period storage nextPeriod = _periods[currentPeriodId_ + 1];
+        if (currentPeriod.end == 0) {
+            _ensureSufficientUnderbid(currentPeriod.fee, offeredFee);
+            _closePeriod(currentPeriod, successionDelay, provingWindow);
         } else {
-            address _nextProverAddress = _nextPeriod.prover;
-            if (_nextProverAddress != address(0)) {
-                _ensureSufficientUnderbid(_nextPeriod.fee, offeredFee);
+            address nextProverAddress = nextPeriod.prover;
+            if (nextProverAddress != address(0)) {
+                _ensureSufficientUnderbid(nextPeriod.fee, offeredFee);
 
                 // Refund the liveness bond to the losing bid
-                balances[_nextProverAddress] += _nextPeriod.stake;
+                balances[nextProverAddress] += nextPeriod.stake;
             }
         }
 
         // Record the next period info
-        uint256 _livenessBond = livenessBond;
-        _updatePeriod(_nextPeriod, msg.sender, offeredFee, _livenessBond);
+        uint256 livenessBond_ = livenessBond;
+        _updatePeriod(nextPeriod, msg.sender, offeredFee, livenessBond_);
 
-        emit ProverOffer(msg.sender, currentPeriod + 1, offeredFee, _livenessBond);
+        emit ProverOffer(msg.sender, currentPeriodId_ + 1, offeredFee, livenessBond_);
     }
 
     /// @inheritdoc IProverManager
@@ -213,12 +218,12 @@ contract ProverManager is IProposerFees, IProverManager {
     /// @dev The liveness bond can only be withdrawn once the period has been fully proven.
     function exit() external {
         Period storage period = _periods[currentPeriodId];
-        address _prover = period.prover;
-        require(msg.sender == _prover, "Not current prover");
+        address prover = period.prover;
+        require(msg.sender == prover, "Not current prover");
         require(period.end == 0, "Prover already exited");
 
         (uint256 end, uint256 deadline) = _closePeriod(period, exitDelay, provingWindow);
-        emit ProverExited(_prover, end, deadline);
+        emit ProverExited(prover, end, deadline);
     }
 
     /// @inheritdoc IProverManager
@@ -312,8 +317,10 @@ contract ProverManager is IProposerFees, IProverManager {
         emit Deposit(user, amount);
     }
 
-    /// @dev implementation of IProverManager.claimProvingVacancy with the option to specify a prover
-    /// This lets the constructor claim the first vacancy on behalf of _initialProver
+    /// @dev implementation of `IProverManager.claimProvingVacancy` with the option to specify a prover
+    /// This also lets the constructor claim the first vacancy on behalf of _initialProver
+    /// @param fee The fee to be set for the new period
+    /// @param prover The address of the prover to be set for the new period
     function _claimProvingVacancy(uint256 fee, address prover) private {
         uint256 periodId = currentPeriodId;
         Period storage period = _periods[periodId];
@@ -356,15 +363,15 @@ contract ProverManager is IProposerFees, IProverManager {
     /// @dev Sets a period's end and deadline timestamps
     /// @param period The period to finalize
     /// @param endDelay The duration (from now) when the period will end
-    /// @param _provingWindow The duration that proofs can be submitted after the end of the period
+    /// @param provingWindow_ The duration that proofs can be submitted after the end of the period
     /// @return end The period's end timestamp
     /// @return deadline The period's deadline timestamp
-    function _closePeriod(Period storage period, uint256 endDelay, uint256 _provingWindow)
+    function _closePeriod(Period storage period, uint256 endDelay, uint256 provingWindow_)
         private
         returns (uint256 end, uint256 deadline)
     {
         end = block.timestamp + endDelay;
-        deadline = end + _provingWindow;
+        deadline = end + provingWindow_;
         period.end = end;
         period.deadline = deadline;
     }

--- a/src/protocol/taiko_alethia/TaikoInbox.sol
+++ b/src/protocol/taiko_alethia/TaikoInbox.sol
@@ -67,8 +67,7 @@ contract TaikoInbox is IInbox, DelayedInclusionStore {
         attributes[LAST_PUBLICATION] = abi.encode(_lastPublicationId);
         attributes[BLOB_REFERENCE] = abi.encode(blobRefRegistry.getRef(_buildBlobIndices(nBlobs)));
 
-        (uint256 publicationFee, uint256 delayedPublicationFee) = proposerFees.getCurrentFees();
-        proposerFees.payPublicationFee{value: publicationFee}(msg.sender, false);
+        proposerFees.payPublicationFee(msg.sender, false);
         _lastPublicationId = publicationFeed.publish(attributes).id;
 
         // Publish each delayed inclusion as a separate publication
@@ -81,7 +80,7 @@ contract TaikoInbox is IInbox, DelayedInclusionStore {
             attributes[LAST_PUBLICATION] = abi.encode(_lastPublicationId);
             attributes[BLOB_REFERENCE] = abi.encode(inclusions[i]);
 
-            proposerFees.payPublicationFee{value: delayedPublicationFee}(msg.sender, true);
+            proposerFees.payPublicationFee(msg.sender, true);
             _lastPublicationId = publicationFeed.publish(attributes).id;
         }
 

--- a/test/BaseProverManager.t.sol
+++ b/test/BaseProverManager.t.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.28;
 
 import "forge-std/Test.sol";
 
+import {BaseProverManager} from "../src/protocol/BaseProverManager.sol";
 import {IProposerFees} from "../src/protocol/IProposerFees.sol";
 import {IProverManager} from "../src/protocol/IProverManager.sol";
-import {ProverManager} from "../src/protocol/taiko_alethia/ProverManager.sol";
 
 import {ICheckpointTracker} from "src/protocol/ICheckpointTracker.sol";
 import {IPublicationFeed} from "src/protocol/IPublicationFeed.sol";
@@ -14,8 +14,21 @@ import {PublicationFeed} from "src/protocol/PublicationFeed.sol";
 import {MockCheckpointTracker} from "test/mocks/MockCheckpointTracker.sol";
 import {NullVerifier} from "test/mocks/NullVerifier.sol";
 
-contract ProverManagerTest is Test {
-    ProverManager proverManager;
+// Configuration parameters.
+uint16 constant MAX_BID_PERCENTAGE = 9500; // 95%
+uint40 constant LIVENESS_WINDOW = 60; // 60 seconds
+uint40 constant SUCCESSION_DELAY = 10;
+uint40 constant EXIT_DELAY = 10;
+uint40 constant PROVING_WINDOW = 30;
+uint96 constant LIVENESS_BOND = 1 ether;
+uint16 constant EVICTOR_INCENTIVE_PERCENTAGE = 500; // 5%
+uint16 constant REWARD_PERCENTAGE = 9000; // 90%
+uint96 constant INITIAL_FEE = 0.1 ether;
+uint16 constant DELAYED_FEE_PERCENTAGE = 15_000; // 150%
+uint256 constant INITIAL_PERIOD = 1;
+
+abstract contract BaseProverManagerTest is Test {
+    BaseProverManager proverManager;
     MockCheckpointTracker checkpointTracker;
     NullVerifier verifier;
     PublicationFeed publicationFeed;
@@ -30,95 +43,9 @@ contract ProverManagerTest is Test {
     address proposer = address(0x202);
     address evictor = address(0x203);
 
-    // Configuration parameters.
-    uint256 constant MAX_BID_PERCENTAGE = 9500; // 95%
-    uint256 constant LIVENESS_WINDOW = 60; // 60 seconds
-    uint256 constant SUCCESSION_DELAY = 10;
-    uint256 constant EXIT_DELAY = 10;
-    uint256 constant PROVING_WINDOW = 30;
-    uint256 constant LIVENESS_BOND = 1 ether;
-    uint256 constant EVICTOR_INCENTIVE_PERCENTAGE = 500; // 5%
-    uint256 constant REWARD_PERCENTAGE = 9000; // 90%
-    uint256 constant INITIAL_FEE = 0.1 ether;
-    uint16 constant DELAYED_FEE_PERCENTAGE = 15_000; // 150%
-    uint256 constant INITIAL_PERIOD = 1;
-
-    function setUp() public {
+    function setUp() public virtual {
         checkpointTracker = new MockCheckpointTracker();
         publicationFeed = new PublicationFeed();
-
-        // Fund the initial prover so the constructor can receive the required livenessBond.
-        vm.deal(initialProver, 10 ether);
-
-        // Create the config struct for the constructor
-        ProverManager.ProverManagerConfig memory config = ProverManager.ProverManagerConfig({
-            maxBidPercentage: MAX_BID_PERCENTAGE,
-            livenessWindow: LIVENESS_WINDOW,
-            successionDelay: SUCCESSION_DELAY,
-            exitDelay: EXIT_DELAY,
-            provingWindow: PROVING_WINDOW,
-            livenessBond: LIVENESS_BOND,
-            evictorIncentivePercentage: EVICTOR_INCENTIVE_PERCENTAGE,
-            rewardPercentage: REWARD_PERCENTAGE,
-            delayedFeePercentage: DELAYED_FEE_PERCENTAGE
-        });
-
-        // Deploy ProverManager with constructor funds.
-        proverManager = new ProverManager{value: LIVENESS_BOND}(
-            inbox, address(checkpointTracker), address(publicationFeed), initialProver, INITIAL_FEE, config
-        );
-
-        // Fund test users.
-        vm.deal(prover1, 10 ether);
-        vm.deal(prover2, 10 ether);
-        vm.deal(evictor, 10 ether);
-        vm.deal(proposer, 10 ether);
-
-        // Fund the Inbox contract.
-        vm.deal(inbox, 10 ether);
-
-        // Deposit enough as a proposer to pay for publications
-        vm.prank(proposer);
-        proverManager.deposit{value: INITIAL_FEE * 10}();
-
-        // Create a publication to trigger the new period
-        vm.warp(vm.getBlockTimestamp() + 1);
-        vm.prank(inbox);
-        proverManager.payPublicationFee(proposer, false);
-    }
-
-    /// --------------------------------------------------------------------------
-    /// Deposit and Withdraw
-    /// --------------------------------------------------------------------------
-    function test_deposit() public {
-        vm.prank(prover1);
-        vm.expectEmit();
-        emit IProposerFees.Deposit(prover1, DEPOSIT_AMOUNT);
-        proverManager.deposit{value: DEPOSIT_AMOUNT}();
-
-        uint256 bal = proverManager.balances(prover1);
-        assertEq(bal, DEPOSIT_AMOUNT, "Deposit did not update balance correctly");
-    }
-
-    function test_withdraw() public {
-        uint256 withdrawAmount = 0.5 ether;
-        _deposit(prover1, DEPOSIT_AMOUNT);
-
-        // Withdraw 0.5 ether.
-        uint256 balanceBefore = prover1.balance;
-        vm.prank(prover1);
-        vm.expectEmit();
-        emit IProposerFees.Withdrawal(prover1, withdrawAmount);
-        proverManager.withdraw(withdrawAmount);
-        uint256 balanceAfter = prover1.balance;
-
-        assertEq(
-            proverManager.balances(prover1),
-            DEPOSIT_AMOUNT - withdrawAmount,
-            "Withdrawal did not update balance correctly"
-        );
-        // Allow a small tolerance for gas.
-        assertApproxEqAbs(balanceAfter, balanceBefore + withdrawAmount, 1e15);
     }
 
     /// --------------------------------------------------------------------------
@@ -167,7 +94,7 @@ contract ProverManagerTest is Test {
         // prover1 deposits sufficient funds
         _deposit(prover1, DEPOSIT_AMOUNT);
 
-        uint256 maxAllowedFee = _maxAllowedFee(INITIAL_FEE);
+        uint96 maxAllowedFee = _maxAllowedFee(INITIAL_FEE);
 
         vm.prank(prover1);
         vm.expectEmit();
@@ -175,7 +102,7 @@ contract ProverManagerTest is Test {
         proverManager.bid(maxAllowedFee);
 
         // Check that period 2 has been created
-        ProverManager.Period memory period = proverManager.getPeriod(2);
+        BaseProverManager.Period memory period = proverManager.getPeriod(2);
 
         assertEq(period.prover, prover1, "Bid not recorded for new period");
         assertEq(period.fee, maxAllowedFee, "Offered fee not set correctly");
@@ -192,7 +119,7 @@ contract ProverManagerTest is Test {
         // First, have prover1 make a successful bid
         _deposit(prover1, DEPOSIT_AMOUNT);
 
-        uint256 firstBidFee = _maxAllowedFee(INITIAL_FEE);
+        uint96 firstBidFee = _maxAllowedFee(INITIAL_FEE);
         vm.prank(prover1);
         proverManager.bid(firstBidFee);
 
@@ -200,7 +127,7 @@ contract ProverManagerTest is Test {
         _deposit(prover2, DEPOSIT_AMOUNT);
 
         // Calculate required fee for second bid
-        uint256 secondBidFee = _maxAllowedFee(firstBidFee);
+        uint96 secondBidFee = _maxAllowedFee(firstBidFee);
 
         vm.prank(prover2);
         vm.expectEmit();
@@ -208,7 +135,7 @@ contract ProverManagerTest is Test {
         proverManager.bid(secondBidFee);
 
         // Check that period 2 now has prover2 as the prover
-        ProverManager.Period memory period = proverManager.getPeriod(2);
+        BaseProverManager.Period memory period = proverManager.getPeriod(2);
         assertEq(period.prover, prover2, "Prover2 should now be the next prover");
         assertEq(period.fee, secondBidFee, "Fee should be updated to prover2's bid");
 
@@ -228,11 +155,11 @@ contract ProverManagerTest is Test {
         uint256 timestampBefore = vm.getBlockTimestamp();
 
         // Make a bid that will outbid the current prover
-        uint256 bidFee = _maxAllowedFee(INITIAL_FEE);
+        uint96 bidFee = _maxAllowedFee(INITIAL_FEE);
         vm.prank(prover1);
         proverManager.bid(bidFee);
 
-        ProverManager.Period memory period = proverManager.getPeriod(1);
+        BaseProverManager.Period memory period = proverManager.getPeriod(1);
         assertEq(
             period.end,
             timestampBefore + SUCCESSION_DELAY,
@@ -247,15 +174,15 @@ contract ProverManagerTest is Test {
         // First, have prover1 make a successful bid
         _deposit(prover1, DEPOSIT_AMOUNT);
 
-        uint256 firstBidFee = _maxAllowedFee(INITIAL_FEE);
+        uint96 firstBidFee = _maxAllowedFee(INITIAL_FEE);
         vm.prank(prover1);
         proverManager.bid(firstBidFee);
 
         // Now have prover2 try to bid with insufficient undercut
         _deposit(prover2, DEPOSIT_AMOUNT);
 
-        uint256 maxFee = _maxAllowedFee(firstBidFee);
-        uint256 insufficientlyReducedFee = maxFee + 1;
+        uint96 maxFee = _maxAllowedFee(firstBidFee);
+        uint96 insufficientlyReducedFee = maxFee + 1;
 
         vm.prank(prover2);
         vm.expectRevert("Offered fee not low enough");
@@ -274,8 +201,8 @@ contract ProverManagerTest is Test {
         _deposit(prover1, DEPOSIT_AMOUNT);
 
         // Calculate a fee that's not low enough
-        uint256 maxFee = _maxAllowedFee(INITIAL_FEE);
-        uint256 insufficientlyReducedFee = maxFee + 1;
+        uint96 maxFee = _maxAllowedFee(INITIAL_FEE);
+        uint96 insufficientlyReducedFee = maxFee + 1;
 
         vm.prank(prover1);
         vm.expectRevert("Offered fee not low enough");
@@ -289,7 +216,7 @@ contract ProverManagerTest is Test {
         IPublicationFeed.PublicationHeader memory header = _insertPublication();
 
         // Capture current period stake before eviction
-        ProverManager.Period memory periodBefore = proverManager.getPeriod(1);
+        BaseProverManager.Period memory periodBefore = proverManager.getPeriod(1);
         uint256 stakeBefore = periodBefore.stake;
         uint256 incentive = _calculatePercentage(stakeBefore, EVICTOR_INCENTIVE_PERCENTAGE);
 
@@ -303,7 +230,7 @@ contract ProverManagerTest is Test {
         proverManager.evictProver(header);
 
         // Verify period 1 is marked as evicted and its stake reduced
-        ProverManager.Period memory periodAfter = proverManager.getPeriod(1);
+        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(1);
         assertEq(periodAfter.deadline, vm.getBlockTimestamp() + EXIT_DELAY, "Prover should be evicted");
         assertEq(periodAfter.end, vm.getBlockTimestamp() + EXIT_DELAY, "Period end not set correctly");
         assertEq(periodAfter.stake, stakeBefore - incentive, "Stake not reduced correctly");
@@ -380,7 +307,7 @@ contract ProverManagerTest is Test {
         proverManager.exit();
 
         // Check that period 1 now has an end time and deadline set
-        ProverManager.Period memory period = proverManager.getPeriod(1);
+        BaseProverManager.Period memory period = proverManager.getPeriod(1);
         assertEq(period.end, vm.getBlockTimestamp() + EXIT_DELAY, "Exit did not set period end correctly");
         assertEq(
             period.deadline, vm.getBlockTimestamp() + EXIT_DELAY + PROVING_WINDOW, "Proving deadline not set correctly"
@@ -422,17 +349,17 @@ contract ProverManagerTest is Test {
 
         // Claim the vacancy
         uint256 prover1BalanceBefore = proverManager.balances(prover1);
-        uint256 newFee = 0.2 ether; //arbitrary new fee
+        uint96 newFee = uint96(0.2 ether); //arbitrary new fee
         vm.prank(prover1);
         proverManager.claimProvingVacancy(newFee);
 
         // Check that period 2(the vacant period) has been closed correctly
-        ProverManager.Period memory period2 = proverManager.getPeriod(2);
+        BaseProverManager.Period memory period2 = proverManager.getPeriod(2);
         assertEq(period2.end, vm.getBlockTimestamp(), "Period 2 end timestamp should be the current timestamp");
         assertEq(period2.deadline, vm.getBlockTimestamp(), "Period 2 deadline should be the current timestamp");
 
         // Check that period 3 has been created correctly
-        ProverManager.Period memory period3 = proverManager.getPeriod(3);
+        BaseProverManager.Period memory period3 = proverManager.getPeriod(3);
         assertEq(period3.prover, prover1, "Prover1 should be the new prover");
         assertEq(period3.fee, newFee, "Fee should be set to the new fee");
         assertEq(period3.stake, LIVENESS_BOND, "Liveness bond should be locked");
@@ -577,7 +504,7 @@ contract ProverManagerTest is Test {
 
         uint256 proverBalanceAfter = proverManager.balances(initialProver);
         uint256 expectedBalance = proverBalanceBefore + INITIAL_FEE * numRegularPublications
-            + _calculatePercentage(INITIAL_FEE, proverManager.delayedFeePercentage()) * numDelayedPublications;
+            + _calculatePercentage(INITIAL_FEE, DELAYED_FEE_PERCENTAGE) * numDelayedPublications;
         assertEq(proverBalanceAfter, expectedBalance, "Prover should receive fees");
     }
 
@@ -619,7 +546,7 @@ contract ProverManagerTest is Test {
         );
 
         // Verify period 1 has been updated
-        ProverManager.Period memory periodAfter = proverManager.getPeriod(1);
+        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(1);
         assertEq(periodAfter.prover, prover1, "Prover should be updated to the new prover");
         assertTrue(periodAfter.pastDeadline, "Period should be marked as past deadline");
 
@@ -682,7 +609,7 @@ contract ProverManagerTest is Test {
         assertEq(prover2BalanceAfter, INITIAL_FEE * 2, "Prover2 should receive the fees");
 
         // Verify the period is marked as past deadline
-        ProverManager.Period memory periodAfter = proverManager.getPeriod(1);
+        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(1);
         assertTrue(periodAfter.pastDeadline, "Period should be marked as past deadline");
     }
 
@@ -849,7 +776,7 @@ contract ProverManagerTest is Test {
         proverManager.finalizePastPeriod(INITIAL_PERIOD, afterPeriodHeader);
 
         // Verify a portion of the stake was transferred to the prover
-        ProverManager.Period memory periodAfter = proverManager.getPeriod(INITIAL_PERIOD);
+        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(INITIAL_PERIOD);
         assertEq(periodAfter.stake, 0, "Stake should be zero after finalization");
 
         uint256 initialProverBalanceAfter = proverManager.balances(initialProver);
@@ -916,7 +843,7 @@ contract ProverManagerTest is Test {
         proverManager.finalizePastPeriod(INITIAL_PERIOD, afterPeriodHeader);
 
         // Verify a portion of the stake was transferred to prover1
-        ProverManager.Period memory periodAfter = proverManager.getPeriod(INITIAL_PERIOD);
+        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(INITIAL_PERIOD);
         assertEq(periodAfter.stake, 0, "Stake should be zero after finalization");
 
         uint256 initialProverBalanceAfter = proverManager.balances(initialProver);
@@ -989,15 +916,19 @@ contract ProverManagerTest is Test {
 
         // Bid as a new prover
         _deposit(prover1, DEPOSIT_AMOUNT);
-        uint256 bidFee = INITIAL_FEE * 2;
+        uint96 bidFee = uint96(INITIAL_FEE * 2);
         vm.prank(prover1);
         proverManager.bid(bidFee);
 
         // Warp to a time after the period has ended.
         vm.warp(vm.getBlockTimestamp() + EXIT_DELAY + 1);
-        (uint256 fee, uint256 delayedFee) = proverManager.getCurrentFees();
+        (uint96 fee, uint96 delayedFee) = proverManager.getCurrentFees();
         assertEq(fee, bidFee, "Fee should be the bid fee");
-        assertEq(delayedFee, _calculatePercentage(bidFee, DELAYED_FEE_PERCENTAGE), "Delayed fee should be the bid fee");
+        assertEq(
+            delayedFee,
+            uint96(_calculatePercentage(bidFee, DELAYED_FEE_PERCENTAGE)),
+            "Delayed fee should be the bid fee"
+        );
     }
 
     // -- HELPERS --
@@ -1040,16 +971,13 @@ contract ProverManagerTest is Test {
         });
     }
 
-    function _deposit(address user, uint256 amount) internal {
-        vm.prank(user);
-        proverManager.deposit{value: amount}();
+    function _deposit(address user, uint256 amount) internal virtual;
+
+    function _maxAllowedFee(uint96 fee) internal pure returns (uint96) {
+        return uint96(_calculatePercentage(fee, MAX_BID_PERCENTAGE));
     }
 
-    function _maxAllowedFee(uint256 fee) internal pure returns (uint256) {
-        return _calculatePercentage(fee, MAX_BID_PERCENTAGE);
-    }
-
-    function _calculatePercentage(uint256 amount, uint256 percentage) internal pure returns (uint256) {
+    function _calculatePercentage(uint256 amount, uint16 percentage) internal pure returns (uint256) {
         return amount * percentage / 10_000;
     }
 

--- a/test/CheckpointTracker.t.sol
+++ b/test/CheckpointTracker.t.sol
@@ -58,15 +58,17 @@ contract CheckpointTrackerTest is Test {
     }
 
     function test_proveTransition_SuccessfulTransition() public {
-        ICheckpointTracker.Checkpoint memory start =
-            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
         ICheckpointTracker.Checkpoint memory end =
             ICheckpointTracker.Checkpoint({publicationId: 3, commitment: keccak256(abi.encode("end"))});
         uint256 numRelevantPublications = 2;
 
         vm.expectEmit();
         emit ICheckpointTracker.CheckpointUpdated(end);
-        tracker.proveTransition(start, end, numRelevantPublications, ZERO_DELAYED_PUBLICATIONS, proof);
+
+        // Empty checkpoint needed to comply with the interface, but not used in `CheckpointTracker`
+        ICheckpointTracker.Checkpoint memory emptyCheckpoint =
+            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: bytes32(0)});
+        tracker.proveTransition(emptyCheckpoint, end, numRelevantPublications, ZERO_DELAYED_PUBLICATIONS, proof);
 
         ICheckpointTracker.Checkpoint memory provenCheckpoint = tracker.getProvenCheckpoint();
         assertEq(provenCheckpoint.publicationId, end.publicationId);
@@ -74,50 +76,28 @@ contract CheckpointTrackerTest is Test {
     }
 
     function test_proveTransition_RevertWhenEndCommitmentIsZero() public {
-        ICheckpointTracker.Checkpoint memory start =
-            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
         ICheckpointTracker.Checkpoint memory end =
             ICheckpointTracker.Checkpoint({publicationId: 3, commitment: bytes32(0)});
         uint256 numRelevantPublications = 2;
 
+        // Empty checkpoint needed to comply with the interface, but not used in `CheckpointTracker`
+        ICheckpointTracker.Checkpoint memory emptyCheckpoint =
+            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: bytes32(0)});
         vm.expectRevert("Checkpoint commitment cannot be 0");
-        tracker.proveTransition(start, end, numRelevantPublications, ZERO_DELAYED_PUBLICATIONS, proof);
-    }
-
-    function test_proveTransition_RevertWhenStartCheckpointNotLatestProven() public {
-        ICheckpointTracker.Checkpoint memory start =
-            ICheckpointTracker.Checkpoint({publicationId: 1, commitment: keccak256(abi.encode("wrong"))});
-        ICheckpointTracker.Checkpoint memory end =
-            ICheckpointTracker.Checkpoint({publicationId: 3, commitment: keccak256(abi.encode("end"))});
-        uint256 numRelevantPublications = 2;
-
-        vm.expectRevert("Start checkpoint must be the latest proven checkpoint");
-        tracker.proveTransition(start, end, numRelevantPublications, ZERO_DELAYED_PUBLICATIONS, proof);
-    }
-
-    function test_proveTransition_RevertWhenEndPublicationNotAfterStart() public {
-        ICheckpointTracker.Checkpoint memory start =
-            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
-        ICheckpointTracker.Checkpoint memory end =
-            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("end"))});
-        // this is nonsensical, but we're testing the publicationId check so I think it makes sense for the other
-        // parameters to match previous tests.
-        uint256 numRelevantPublications = 2;
-
-        vm.expectRevert("End publication must be after the last proven publication");
-        tracker.proveTransition(start, end, numRelevantPublications, ZERO_DELAYED_PUBLICATIONS, proof);
+        tracker.proveTransition(emptyCheckpoint, end, numRelevantPublications, ZERO_DELAYED_PUBLICATIONS, proof);
     }
 
     function test_proveTransition_RevertWhenNumDelayedPublicationsGreaterThanNumPublications() public {
-        ICheckpointTracker.Checkpoint memory start =
-            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: keccak256(abi.encode("genesis"))});
         ICheckpointTracker.Checkpoint memory end =
             ICheckpointTracker.Checkpoint({publicationId: 3, commitment: keccak256(abi.encode("end"))});
         uint256 numRelevantPublications = 2;
         uint256 numDelayedPublications = 3;
 
+        // Empty checkpoint needed to comply with the interface, but not used in `CheckpointTracker`
+        ICheckpointTracker.Checkpoint memory emptyCheckpoint =
+            ICheckpointTracker.Checkpoint({publicationId: 0, commitment: bytes32(0)});
         vm.expectRevert("Number of delayed publications cannot be greater than the total number of publications");
-        tracker.proveTransition(start, end, numRelevantPublications, numDelayedPublications, proof);
+        tracker.proveTransition(emptyCheckpoint, end, numRelevantPublications, numDelayedPublications, proof);
     }
 
     function createSampleFeed() private {

--- a/test/ERC20ProverManager.t.sol
+++ b/test/ERC20ProverManager.t.sol
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+
+import {BaseProverManager} from "../src/protocol/BaseProverManager.sol";
+import {ERC20ProverManager} from "../src/protocol/ERC20ProverManager.sol";
+
+import {IProposerFees} from "../src/protocol/IProposerFees.sol";
+import {ICheckpointTracker} from "src/protocol/ICheckpointTracker.sol";
+import {IPublicationFeed} from "src/protocol/IPublicationFeed.sol";
+import {PublicationFeed} from "src/protocol/PublicationFeed.sol";
+
+import {MockCheckpointTracker} from "test/mocks/MockCheckpointTracker.sol";
+
+import {MockERC20} from "test/mocks/MockERC20.sol";
+import {NullVerifier} from "test/mocks/NullVerifier.sol";
+
+import {BaseProverManagerTest} from "./BaseProverManager.t.sol";
+import {
+    DELAYED_FEE_PERCENTAGE,
+    EVICTOR_INCENTIVE_PERCENTAGE,
+    EXIT_DELAY,
+    INITIAL_FEE,
+    INITIAL_PERIOD,
+    LIVENESS_BOND,
+    LIVENESS_WINDOW,
+    MAX_BID_PERCENTAGE,
+    PROVING_WINDOW,
+    REWARD_PERCENTAGE,
+    SUCCESSION_DELAY
+} from "./BaseProverManager.t.sol";
+
+import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+
+contract ERC20ProverManagerMock is ERC20ProverManager {
+    constructor(
+        address _inbox,
+        address _checkpointTracker,
+        address _publicationFeed,
+        address _initialProver,
+        uint96 _initialFee,
+        address _token,
+        uint256 _initialDeposit
+    )
+        ERC20ProverManager(
+            _inbox,
+            _checkpointTracker,
+            _publicationFeed,
+            _initialProver,
+            _initialFee,
+            _token,
+            _initialDeposit
+        )
+    {}
+
+    function _maxBidPercentage() internal view virtual override returns (uint16) {
+        return MAX_BID_PERCENTAGE;
+    }
+
+    function _livenessWindow() internal view virtual override returns (uint40) {
+        return LIVENESS_WINDOW;
+    }
+
+    function _successionDelay() internal view virtual override returns (uint40) {
+        return SUCCESSION_DELAY;
+    }
+
+    function _exitDelay() internal view virtual override returns (uint40) {
+        return EXIT_DELAY;
+    }
+
+    function _provingWindow() internal view virtual override returns (uint40) {
+        return PROVING_WINDOW;
+    }
+
+    function _livenessBond() internal view virtual override returns (uint96) {
+        return LIVENESS_BOND;
+    }
+
+    function _evictorIncentivePercentage() internal view virtual override returns (uint16) {
+        return EVICTOR_INCENTIVE_PERCENTAGE;
+    }
+
+    function _rewardPercentage() internal view virtual override returns (uint16) {
+        return REWARD_PERCENTAGE;
+    }
+
+    function _delayedFeePercentage() internal view virtual override returns (uint16) {
+        return DELAYED_FEE_PERCENTAGE;
+    }
+}
+
+contract ERC20ProverManagerTest is BaseProverManagerTest {
+    // Holds a reference to `proverManager` but with the type ERC20ProverManager to be
+    // able to call functions that are specific to the ERC20ProverManager (i.e., `deposit`)
+    ERC20ProverManager erc20ProverManager;
+
+    MockERC20 mockToken;
+    bytes32 constant SALT = "DEPLOY_SALT";
+
+    function setUp() public override {
+        super.setUp();
+
+        // Create a new mock ERC20 token
+        mockToken = new MockERC20();
+
+        // Mint tokens to relevant addresses
+        mockToken.mint(initialProver, LIVENESS_BOND + 10 ether);
+        mockToken.mint(prover1, 10 ether);
+        mockToken.mint(prover2, 10 ether);
+        mockToken.mint(evictor, 10 ether);
+        mockToken.mint(proposer, 10 ether);
+        mockToken.mint(inbox, 10 ether);
+
+        // Deploy the ERC20ProverManager to a deterministic address using CREATE2 and approve it to spend tokens from
+        // the initial prover before deployment
+        bytes memory args = abi.encode(
+            inbox,
+            address(checkpointTracker),
+            address(publicationFeed),
+            initialProver,
+            INITIAL_FEE,
+            address(mockToken),
+            LIVENESS_BOND
+        );
+        address proverManagerAddress =
+            vm.computeCreate2Address(SALT, hashInitCode(type(ERC20ProverManagerMock).creationCode, args));
+        vm.prank(initialProver);
+        mockToken.approve(proverManagerAddress, LIVENESS_BOND);
+
+        // Create ProverManager instance
+        proverManager = new ERC20ProverManagerMock{salt: SALT}(
+            inbox,
+            address(checkpointTracker),
+            address(publicationFeed),
+            initialProver,
+            INITIAL_FEE,
+            address(mockToken),
+            LIVENESS_BOND
+        );
+        erc20ProverManager = ERC20ProverManager(address(proverManager));
+
+        // Approve tokens for all test users
+        vm.prank(initialProver);
+        mockToken.approve(address(proverManager), type(uint256).max);
+
+        vm.prank(prover1);
+        mockToken.approve(address(proverManager), type(uint256).max);
+
+        vm.prank(prover2);
+        mockToken.approve(address(proverManager), type(uint256).max);
+
+        vm.prank(evictor);
+        mockToken.approve(address(proverManager), type(uint256).max);
+
+        vm.prank(proposer);
+        mockToken.approve(address(proverManager), type(uint256).max);
+
+        vm.prank(inbox);
+        mockToken.approve(address(proverManager), type(uint256).max);
+
+        // Deposit enough as a proposer to pay for publications
+        vm.prank(proposer);
+        erc20ProverManager.deposit(INITIAL_FEE * 10);
+
+        // Create a publication to trigger the new period
+        vm.warp(vm.getBlockTimestamp() + 1);
+        vm.prank(inbox);
+        proverManager.payPublicationFee(proposer, false);
+    }
+
+    function test_setUp_TokenBalance() public view {
+        // Test that the contract holds the correct amount of tokens after setup
+        uint256 expectedBalance = LIVENESS_BOND + (INITIAL_FEE * 10); // Initial liveness bond + proposer deposit
+        uint256 actualBalance = mockToken.balanceOf(address(proverManager));
+
+        assertEq(actualBalance, expectedBalance, "Contract does not hold the correct token balance");
+    }
+
+    function test_constructor_RevertWhen_ZeroTokenAddress() public {
+        vm.expectRevert("Token address cannot be 0");
+        new ERC20ProverManagerMock(
+            inbox,
+            address(checkpointTracker),
+            address(publicationFeed),
+            initialProver,
+            INITIAL_FEE,
+            address(0), // Zero address for token
+            LIVENESS_BOND
+        );
+    }
+
+    function test_deposit() public {
+        vm.prank(prover1);
+        vm.expectEmit();
+        emit IProposerFees.Deposit(prover1, DEPOSIT_AMOUNT);
+        erc20ProverManager.deposit(DEPOSIT_AMOUNT);
+
+        uint256 bal = proverManager.balances(prover1);
+        assertEq(bal, DEPOSIT_AMOUNT, "Deposit did not update balance correctly");
+
+        // Also check that the token was transferred from the user to the contract
+        uint256 contractTokenBalance = mockToken.balanceOf(address(proverManager));
+        assertEq(
+            contractTokenBalance,
+            LIVENESS_BOND + (INITIAL_FEE * 10) + DEPOSIT_AMOUNT,
+            "Contract token balance not updated correctly"
+        );
+    }
+
+    function test_deposit_RevertWhen_NotApproved() public {
+        // Create a new address that hasn't approved tokens
+        address newUser = address(0x999);
+        mockToken.mint(newUser, DEPOSIT_AMOUNT);
+
+        // Attempt to deposit without approving first
+        vm.prank(newUser);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Errors.ERC20InsufficientAllowance.selector, address(proverManager), 0, DEPOSIT_AMOUNT
+            )
+        );
+        erc20ProverManager.deposit(DEPOSIT_AMOUNT);
+    }
+
+    function test_deposit_RevertWhen_InsufficientBalance() public {
+        // Create a new address with insufficient token balance
+        address poorUser = address(0x888);
+        uint256 poorUserBalance = DEPOSIT_AMOUNT / 2;
+        mockToken.mint(poorUser, poorUserBalance);
+
+        vm.startPrank(poorUser);
+        mockToken.approve(address(proverManager), DEPOSIT_AMOUNT);
+
+        // Attempt to deposit more than the user has
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC20Errors.ERC20InsufficientBalance.selector, poorUser, poorUserBalance, DEPOSIT_AMOUNT
+            )
+        );
+        erc20ProverManager.deposit(DEPOSIT_AMOUNT);
+    }
+
+    function test_withdraw() public {
+        uint256 withdrawAmount = 0.5 ether;
+        _deposit(prover1, DEPOSIT_AMOUNT);
+
+        // Get the token balance before withdrawal
+        uint256 tokenBalanceBefore = mockToken.balanceOf(prover1);
+
+        // Withdraw tokens
+        vm.prank(prover1);
+        vm.expectEmit();
+        emit IProposerFees.Withdrawal(prover1, withdrawAmount);
+        proverManager.withdraw(withdrawAmount);
+
+        // Get the token balance after withdrawal
+        uint256 tokenBalanceAfter = mockToken.balanceOf(prover1);
+
+        assertEq(
+            proverManager.balances(prover1),
+            DEPOSIT_AMOUNT - withdrawAmount,
+            "Withdrawal did not update balance correctly"
+        );
+
+        assertEq(
+            tokenBalanceAfter,
+            tokenBalanceBefore + withdrawAmount,
+            "Token balance did not increase by the correct amount"
+        );
+    }
+
+    // -- HELPERS --
+    function _deposit(address user, uint256 amount) internal override {
+        vm.prank(user);
+        erc20ProverManager.deposit(amount);
+    }
+}

--- a/test/ETHProverManager.t.sol
+++ b/test/ETHProverManager.t.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+
+import {BaseProverManager} from "../src/protocol/BaseProverManager.sol";
+import {ETHProverManager} from "../src/protocol/ETHProverManager.sol";
+import {IProposerFees} from "../src/protocol/IProposerFees.sol";
+
+import {ICheckpointTracker} from "src/protocol/ICheckpointTracker.sol";
+import {IPublicationFeed} from "src/protocol/IPublicationFeed.sol";
+import {PublicationFeed} from "src/protocol/PublicationFeed.sol";
+
+import {MockCheckpointTracker} from "test/mocks/MockCheckpointTracker.sol";
+import {NullVerifier} from "test/mocks/NullVerifier.sol";
+
+import {BaseProverManagerTest} from "./BaseProverManager.t.sol";
+import {
+    DELAYED_FEE_PERCENTAGE,
+    EVICTOR_INCENTIVE_PERCENTAGE,
+    EXIT_DELAY,
+    INITIAL_FEE,
+    INITIAL_PERIOD,
+    LIVENESS_BOND,
+    LIVENESS_WINDOW,
+    MAX_BID_PERCENTAGE,
+    PROVING_WINDOW,
+    REWARD_PERCENTAGE,
+    SUCCESSION_DELAY
+} from "./BaseProverManager.t.sol";
+
+contract ETHProverManagerMock is ETHProverManager {
+    constructor(
+        address _inbox,
+        address _checkpointTracker,
+        address _publicationFeed,
+        address _initialProver,
+        uint96 _initialFee
+    ) payable ETHProverManager(_inbox, _checkpointTracker, _publicationFeed, _initialProver, _initialFee) {}
+
+    function _maxBidPercentage() internal view virtual override returns (uint16) {
+        return MAX_BID_PERCENTAGE;
+    }
+
+    function _livenessWindow() internal view virtual override returns (uint40) {
+        return LIVENESS_WINDOW;
+    }
+
+    function _successionDelay() internal view virtual override returns (uint40) {
+        return SUCCESSION_DELAY;
+    }
+
+    function _exitDelay() internal view virtual override returns (uint40) {
+        return EXIT_DELAY;
+    }
+
+    function _provingWindow() internal view virtual override returns (uint40) {
+        return PROVING_WINDOW;
+    }
+
+    function _livenessBond() internal view virtual override returns (uint96) {
+        return LIVENESS_BOND;
+    }
+
+    function _evictorIncentivePercentage() internal view virtual override returns (uint16) {
+        return EVICTOR_INCENTIVE_PERCENTAGE;
+    }
+
+    function _rewardPercentage() internal view virtual override returns (uint16) {
+        return REWARD_PERCENTAGE;
+    }
+
+    function _delayedFeePercentage() internal view virtual override returns (uint16) {
+        return DELAYED_FEE_PERCENTAGE;
+    }
+}
+
+contract ETHProverManagerTest is BaseProverManagerTest {
+    // Holds a reference to `proverManager` but with the type ETHProverManager to be
+    // able to call functions that are specific to the ETHProverManager(i.e. `deposit`)
+    ETHProverManager ethProverManager;
+
+    function setUp() public override {
+        super.setUp();
+        proverManager = new ETHProverManagerMock{value: LIVENESS_BOND}(
+            inbox, address(checkpointTracker), address(publicationFeed), initialProver, INITIAL_FEE
+        );
+        ethProverManager = ETHProverManager(payable(address(proverManager)));
+
+        // Fund the initial prover so the constructor can receive the required livenessBond.
+        vm.deal(initialProver, 10 ether);
+
+        // Fund test users.
+        vm.deal(prover1, 10 ether);
+        vm.deal(prover2, 10 ether);
+        vm.deal(evictor, 10 ether);
+        vm.deal(proposer, 10 ether);
+
+        // Fund the Inbox contract.
+        vm.deal(inbox, 10 ether);
+
+        // Deposit enough as a proposer to pay for publications
+        vm.prank(proposer);
+        ethProverManager.deposit{value: INITIAL_FEE * 10}();
+
+        // Create a publication to trigger the new period
+        vm.warp(vm.getBlockTimestamp() + 1);
+        vm.prank(inbox);
+        proverManager.payPublicationFee(proposer, false);
+    }
+
+    function test_setUp_EthBalance() public view {
+        // Test that the contract holds the correct amount of ETH after setup
+        uint256 expectedBalance = LIVENESS_BOND + (INITIAL_FEE * 10); // Initial liveness bond + proposer deposit
+        uint256 actualBalance = address(proverManager).balance;
+
+        assertEq(actualBalance, expectedBalance, "Contract does not hold the correct ETH balance");
+    }
+
+    function test_deposit() public {
+        vm.prank(prover1);
+        vm.expectEmit();
+        emit IProposerFees.Deposit(prover1, DEPOSIT_AMOUNT);
+        ethProverManager.deposit{value: DEPOSIT_AMOUNT}();
+
+        uint256 bal = proverManager.balances(prover1);
+        assertEq(bal, DEPOSIT_AMOUNT, "Deposit did not update balance correctly");
+    }
+
+    function test_withdraw() public {
+        uint256 withdrawAmount = 0.5 ether;
+        _deposit(prover1, DEPOSIT_AMOUNT);
+
+        // Withdraw 0.5 ether.
+        uint256 balanceBefore = prover1.balance;
+        vm.prank(prover1);
+        vm.expectEmit();
+        emit IProposerFees.Withdrawal(prover1, withdrawAmount);
+        proverManager.withdraw(withdrawAmount);
+        uint256 balanceAfter = prover1.balance;
+
+        assertEq(
+            proverManager.balances(prover1),
+            DEPOSIT_AMOUNT - withdrawAmount,
+            "Withdrawal did not update balance correctly"
+        );
+        // Allow a small tolerance for gas.
+        assertApproxEqAbs(balanceAfter, balanceBefore + withdrawAmount, 1e15);
+    }
+
+    function _deposit(address user, uint256 amount) internal override {
+        vm.prank(user);
+        ethProverManager.deposit{value: amount}();
+    }
+}

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -75,10 +75,14 @@ contract ProverManagerTest is Test {
         // Fund the Inbox contract.
         vm.deal(inbox, 10 ether);
 
+        // Deposit enough as a proposer to pay for publications
+        vm.prank(proposer);
+        proverManager.deposit{value: INITIAL_FEE * 10}();
+
         // Create a publication to trigger the new period
         vm.warp(vm.getBlockTimestamp() + 1);
         vm.prank(inbox);
-        proverManager.payPublicationFee{value: INITIAL_FEE}(proposer, false);
+        proverManager.payPublicationFee(proposer, false);
     }
 
     /// --------------------------------------------------------------------------
@@ -126,21 +130,10 @@ contract ProverManagerTest is Test {
         uint256 balanceBefore = proverManager.balances(proposer);
         // Call payPublicationFee from the inbox.
         vm.prank(inbox);
-        proverManager.payPublicationFee{value: 0}(proposer, false);
+        proverManager.payPublicationFee(proposer, false);
 
         uint256 balanceAfter = proverManager.balances(proposer);
         assertEq(balanceAfter, balanceBefore - INITIAL_FEE, "Publication fee not deducted properly");
-    }
-
-    function test_payPublicationFee_AllowsToSendEth() public {
-        // Call payPublicationFee from the inbox.
-        vm.prank(inbox);
-        vm.expectEmit();
-        emit ProverManager.Deposit(proposer, DEPOSIT_AMOUNT);
-        proverManager.payPublicationFee{value: DEPOSIT_AMOUNT}(proposer, false);
-
-        uint256 balanceAfter = proverManager.balances(proposer);
-        assertEq(balanceAfter, DEPOSIT_AMOUNT - INITIAL_FEE, "Publication fee not deducted properly");
     }
 
     function test_payPublicationFee_AdvancesPeriod() public {
@@ -157,7 +150,7 @@ contract ProverManagerTest is Test {
         vm.prank(inbox);
         vm.expectEmit();
         emit ProverManager.NewPeriod(2);
-        proverManager.payPublicationFee{value: INITIAL_FEE}(proposer, false);
+        proverManager.payPublicationFee(proposer, false);
     }
 
     function test_payPublicationFee_RevertWhen_NotInbox() public {
@@ -420,7 +413,7 @@ contract ProverManagerTest is Test {
 
         //Submit a publication to advance to the vacant period(period 2)
         vm.prank(inbox);
-        proverManager.payPublicationFee{value: INITIAL_FEE}(proposer, false);
+        proverManager.payPublicationFee(proposer, false);
 
         // Ensure prover1 has enough funds
         _deposit(prover1, DEPOSIT_AMOUNT);
@@ -455,7 +448,7 @@ contract ProverManagerTest is Test {
 
         //Submit a publication to advance to the vacant period(period 2)
         vm.prank(inbox);
-        proverManager.payPublicationFee{value: INITIAL_FEE}(proposer, false);
+        proverManager.payPublicationFee(proposer, false);
 
         // Ensure prover1 has enough funds
         _deposit(prover1, DEPOSIT_AMOUNT);
@@ -497,7 +490,7 @@ contract ProverManagerTest is Test {
 
         //Submit a publication to advance to the vacant period(period 2)
         vm.prank(inbox);
-        proverManager.payPublicationFee{value: INITIAL_FEE}(proposer, false);
+        proverManager.payPublicationFee(proposer, false);
 
         // Attempt to claim the vacancy without sufficient balance
         vm.prank(prover2);

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.28;
 
 import "forge-std/Test.sol";
 
+import {IProposerFees} from "../src/protocol/IProposerFees.sol";
+import {IProverManager} from "../src/protocol/IProverManager.sol";
 import {ProverManager} from "../src/protocol/taiko_alethia/ProverManager.sol";
 
 import {ICheckpointTracker} from "src/protocol/ICheckpointTracker.sol";
@@ -91,7 +93,7 @@ contract ProverManagerTest is Test {
     function test_deposit() public {
         vm.prank(prover1);
         vm.expectEmit();
-        emit ProverManager.Deposit(prover1, DEPOSIT_AMOUNT);
+        emit IProposerFees.Deposit(prover1, DEPOSIT_AMOUNT);
         proverManager.deposit{value: DEPOSIT_AMOUNT}();
 
         uint256 bal = proverManager.balances(prover1);
@@ -106,7 +108,7 @@ contract ProverManagerTest is Test {
         uint256 balanceBefore = prover1.balance;
         vm.prank(prover1);
         vm.expectEmit();
-        emit ProverManager.Withdrawal(prover1, withdrawAmount);
+        emit IProposerFees.Withdrawal(prover1, withdrawAmount);
         proverManager.withdraw(withdrawAmount);
         uint256 balanceAfter = prover1.balance;
 
@@ -149,7 +151,7 @@ contract ProverManagerTest is Test {
         // Call payPublicationFee from the inbox and check that the period has been advanced.
         vm.prank(inbox);
         vm.expectEmit();
-        emit ProverManager.NewPeriod(2);
+        emit IProverManager.NewPeriod(2);
         proverManager.payPublicationFee(proposer, false);
     }
 
@@ -169,7 +171,7 @@ contract ProverManagerTest is Test {
 
         vm.prank(prover1);
         vm.expectEmit();
-        emit ProverManager.ProverOffer(prover1, 2, maxAllowedFee, LIVENESS_BOND);
+        emit IProverManager.ProverOffer(prover1, 2, maxAllowedFee, LIVENESS_BOND);
         proverManager.bid(maxAllowedFee);
 
         // Check that period 2 has been created
@@ -202,7 +204,7 @@ contract ProverManagerTest is Test {
 
         vm.prank(prover2);
         vm.expectEmit();
-        emit ProverManager.ProverOffer(prover2, 2, secondBidFee, LIVENESS_BOND);
+        emit IProverManager.ProverOffer(prover2, 2, secondBidFee, LIVENESS_BOND);
         proverManager.bid(secondBidFee);
 
         // Check that period 2 now has prover2 as the prover
@@ -295,7 +297,7 @@ contract ProverManagerTest is Test {
         vm.warp(vm.getBlockTimestamp() + LIVENESS_WINDOW + 1);
         vm.prank(evictor);
         vm.expectEmit();
-        emit ProverManager.ProverEvicted(
+        emit IProverManager.ProverEvicted(
             initialProver, evictor, vm.getBlockTimestamp() + EXIT_DELAY, stakeBefore - incentive
         );
         proverManager.evictProver(header);
@@ -372,7 +374,7 @@ contract ProverManagerTest is Test {
         // initialProver is the prover for period 1
         vm.prank(initialProver);
         vm.expectEmit();
-        emit ProverManager.ProverExited(
+        emit IProverManager.ProverExited(
             initialProver, vm.getBlockTimestamp() + EXIT_DELAY, vm.getBlockTimestamp() + EXIT_DELAY + PROVING_WINDOW
         );
         proverManager.exit();
@@ -469,7 +471,7 @@ contract ProverManagerTest is Test {
         _deposit(proposer, INITIAL_FEE);
         vm.prank(inbox);
         vm.expectEmit();
-        emit ProverManager.NewPeriod(periodAfter + 1);
+        emit IProverManager.NewPeriod(periodAfter + 1);
         proverManager.payPublicationFee(proposer, false);
     }
 

--- a/test/mocks/MockCheckpointTracker.sol
+++ b/test/mocks/MockCheckpointTracker.sol
@@ -17,6 +17,7 @@ contract MockCheckpointTracker is ICheckpointTracker {
         Checkpoint calldata start,
         Checkpoint calldata end,
         uint256 numPublications,
+        uint256 numDelayedPublications,
         bytes calldata proof
     ) external {}
 

--- a/test/mocks/MockCheckpointTracker.sol
+++ b/test/mocks/MockCheckpointTracker.sol
@@ -14,7 +14,7 @@ contract MockCheckpointTracker is ICheckpointTracker {
 
     /// @notice Do nothing. All checkpoints and proofs are accepted.
     function proveTransition(
-        Checkpoint calldata start,
+        Checkpoint calldata,
         Checkpoint calldata end,
         uint256 numPublications,
         uint256 numDelayedPublications,

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title MockERC20
+/// @notice A simple mock implementation of ERC20 for testing purposes
+contract MockERC20 is ERC20 {
+    constructor() ERC20("MockToken", "MOCK") {}
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+}

--- a/test/mocks/NullVerifier.sol
+++ b/test/mocks/NullVerifier.sol
@@ -11,6 +11,7 @@ contract NullVerifier is IVerifier {
         bytes32, /* startCheckPoint */
         bytes32, /* endCheckPoint */
         uint256, /* numPublications */
+        uint256, /* numDelayedPublications */
         bytes calldata /* proof */
     ) external {}
 }


### PR DESCRIPTION
Fixes #68 

This PR is an attempt to give the flexibility to price delayed publications differently, while still keeping them as part of the fees(more details can be found on the issue).

Pros of this approach:
- Flexibility, delayed publications can be priced differently than regular pubs(we are using a uint16, so they can represent up to ~6.55x the normal fee - alternatively we can use a uint24 and that would allow ~167.77x)
- Delayed fees are treated just as regular fees, and payed to provers when calling prove(no need to wait until the end of the period or put them in the stake)

Cons:
For now it:
- <del> Uses more storage since we have a new variable for the `delayedFeePercentage`. This shouldn't be an issue once we pack the storage variables</del>
- <del>Adds another config parameter(which will be abstracted with an internal function soon)</del>

These both are fixed in #100 

This PR also:
- Removes the ability to deposit from the `payPublicationFee` function
- Fixes a bug where the Inbox was always sending the publication fee as part of the call to `payPublicationFee`. Now we rely on the proposer to deposit before and the call this function. This saves some gas since we don't need to query the fees beforehand