### PR TITLE
[1/2] Simplify commitment store

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,11 +10,11 @@ stop-anvil:
     lsof -ti:8545 | xargs -r kill
     lsof -ti:8546 | xargs -r kill
 
-test +ARGS:
+test +ARGS='':
     # Run all unit tests
     forge test {{ARGS}} --no-match-path 'test/signal/**'
 
-test-int +ARGS:
+test-int +ARGS='':
     # Run all tests
     forge test {{ARGS}}
 

--- a/src/libs/LibSignal.sol
+++ b/src/libs/LibSignal.sol
@@ -68,7 +68,7 @@ library LibSignal {
         bytes32 root,
         bytes[] memory accountProof,
         bytes[] memory storageProof
-    ) internal pure {
+    ) internal view {
         bytes32 encodedBool = bytes32(uint256(1));
         LibTrieProof.verifyMerkleProof(
             root, sender, deriveSlot(value, sender, namespace), encodedBool, accountProof, storageProof

--- a/src/libs/LibSignal.sol
+++ b/src/libs/LibSignal.sol
@@ -68,7 +68,7 @@ library LibSignal {
         bytes32 root,
         bytes[] memory accountProof,
         bytes[] memory storageProof
-    ) internal view {
+    ) internal pure {
         bytes32 encodedBool = bytes32(uint256(1));
         LibTrieProof.verifyMerkleProof(
             root, sender, deriveSlot(value, sender, namespace), encodedBool, accountProof, storageProof

--- a/src/protocol/CheckpointTracker.sol
+++ b/src/protocol/CheckpointTracker.sol
@@ -7,15 +7,14 @@ import {IPublicationFeed} from "./IPublicationFeed.sol";
 import {IVerifier} from "./IVerifier.sol";
 
 contract CheckpointTracker is ICheckpointTracker {
-    /// @notice The publication id of the current proven checkpoint representing the latest verified state of the rollup
-    /// @dev A checkpoint commitment is any value (typically a state root) that uniquely identifies
-    /// the state of the rollup at a specific point in time
+    /// @dev The publication id of the current proven checkpoint representing
+    /// the latest verified state of the rollup
     uint256 private _provenPublicationId;
 
     IPublicationFeed public immutable publicationFeed;
     IVerifier public immutable verifier;
     ICommitmentStore public immutable commitmentStore;
-    address public proverManager;
+    address public immutable proverManager;
 
     /// @param _genesis the checkpoint commitment describing the initial state of the rollup
     /// @param _publicationFeed the input data source that updates the state of this rollup
@@ -73,11 +72,16 @@ contract CheckpointTracker is ICheckpointTracker {
         _updateCheckpoint(end.publicationId, end.commitment);
     }
 
+    /// @inheritdoc ICheckpointTracker
     function getProvenCheckpoint() public view returns (Checkpoint memory provenCheckpoint) {
         provenCheckpoint.publicationId = _provenPublicationId;
         provenCheckpoint.commitment = commitmentStore.commitmentAt(address(this), provenCheckpoint.publicationId);
     }
 
+    /// @dev Updates the proven checkpoint to a new publication ID and commitment
+    /// @dev Stores the commitment in the commitment store and emits an event
+    /// @param publicationId The ID of the publication to set as the latest proven checkpoint
+    /// @param commitment The checkpoint commitment representing the state at the given publication ID
     function _updateCheckpoint(uint256 publicationId, bytes32 commitment) internal {
         _provenPublicationId = publicationId;
         commitmentStore.storeCommitment(publicationId, commitment);

--- a/src/protocol/CheckpointTracker.sol
+++ b/src/protocol/CheckpointTracker.sol
@@ -10,7 +10,7 @@ contract CheckpointTracker is ICheckpointTracker {
     /// @notice The publication id of the current proven checkpoint representing the latest verified state of the rollup
     /// @dev A checkpoint commitment is any value (typically a state root) that uniquely identifies
     /// the state of the rollup at a specific point in time
-    uint256 _provenPublicationId;
+    uint256 private _provenPublicationId;
 
     IPublicationFeed public immutable publicationFeed;
     IVerifier public immutable verifier;
@@ -29,21 +29,16 @@ contract CheckpointTracker is ICheckpointTracker {
         address _proverManager,
         address _commitmentStore
     ) {
+        // set the genesis checkpoint commitment of the rollup - genesis is trusted to be correct
+        require(_genesis != 0, "genesis checkpoint commitment cannot be 0");
         publicationFeed = IPublicationFeed(_publicationFeed);
-        if (_genesis != 0) {
-            uint256 latestPublicationId = publicationFeed.getNextPublicationId() - 1;
-            require(
-                _genesis == publicationFeed.getPublicationHash(latestPublicationId),
-                GenesisNotLatestPublication(latestPublicationId)
-            );
-            _updateCheckpoint(latestPublicationId, _genesis);
-        } else {
-            _updateCheckpoint(0, _genesis);
-        }
+        uint256 latestPublicationId = publicationFeed.getNextPublicationId() - 1;
 
         verifier = IVerifier(_verifier);
         commitmentStore = ICommitmentStore(_commitmentStore);
         proverManager = _proverManager;
+
+        _updateCheckpoint(latestPublicationId, _genesis);
     }
 
     /// @inheritdoc ICheckpointTracker

--- a/src/protocol/CommitmentStore.sol
+++ b/src/protocol/CommitmentStore.sol
@@ -3,12 +3,8 @@ pragma solidity ^0.8.28;
 
 import {ICommitmentStore} from "./ICommitmentStore.sol";
 
-import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-
 /// @dev Base contract for storing commitments.
 abstract contract CommitmentStore is ICommitmentStore {
-    using SafeCast for uint256;
-
     mapping(address source => mapping(uint256 height => bytes32 commitment)) private _commitments;
 
     /// @inheritdoc ICommitmentStore

--- a/src/protocol/CommitmentStore.sol
+++ b/src/protocol/CommitmentStore.sol
@@ -10,16 +10,16 @@ import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 abstract contract CommitmentStore is ICommitmentStore {
     using SafeCast for uint256;
 
-    mapping(address source => mapping(uint256 index => bytes32 commitment)) private _commitments;
+    mapping(address source => mapping(uint256 height => bytes32 commitment)) private _commitments;
 
     /// @inheritdoc ICommitmentStore
-    function commitmentAt(address source, uint256 index) public view virtual returns (bytes32) {
-        return _commitments[source][index];
+    function commitmentAt(address source, uint256 height) public view virtual returns (bytes32) {
+        return _commitments[source][height];
     }
 
     /// @inheritdoc ICommitmentStore
-    function storeCommitment(uint256 index, bytes32 commitment) external virtual {
-        _commitments[msg.sender][index] = commitment;
-        emit CommitmentStored(msg.sender, index, commitment);
+    function storeCommitment(uint256 height, bytes32 commitment) external virtual {
+        _commitments[msg.sender][height] = commitment;
+        emit CommitmentStored(msg.sender, height, commitment);
     }
 }

--- a/src/protocol/CommitmentStore.sol
+++ b/src/protocol/CommitmentStore.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {ICheckpointTracker} from "./ICheckpointTracker.sol";
 import {ICommitmentStore} from "./ICommitmentStore.sol";
 
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";

--- a/src/protocol/CommitmentStore.sol
+++ b/src/protocol/CommitmentStore.sol
@@ -4,51 +4,22 @@ pragma solidity ^0.8.28;
 import {ICheckpointTracker} from "./ICheckpointTracker.sol";
 import {ICommitmentStore} from "./ICommitmentStore.sol";
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /// @dev Base contract for storing commitments.
-abstract contract CommitmentStore is ICommitmentStore, Ownable {
+abstract contract CommitmentStore is ICommitmentStore {
     using SafeCast for uint256;
 
-    address private _authorizedCommitter;
+    mapping(address source => mapping(uint256 index => bytes32 commitment)) private _commitments;
 
-    mapping(uint256 height => bytes32 commitment) private _commitments;
-
-    /// @param _rollupOperator The address of the rollup operator
-    constructor(address _rollupOperator) Ownable(_rollupOperator) {}
-
-    /// @dev Reverts if the caller is not the `authorizedCommitter`.
-    modifier onlyAuthorizedCommitter() {
-        _checkAuthorizedCommitter(msg.sender);
-        _;
+    /// @inheritdoc ICommitmentStore
+    function commitmentAt(address source, uint256 index) public view virtual returns (bytes32) {
+        return _commitments[source][index];
     }
 
     /// @inheritdoc ICommitmentStore
-    function authorizedCommitter() public view virtual returns (address) {
-        return _authorizedCommitter;
-    }
-
-    /// @inheritdoc ICommitmentStore
-    function setAuthorizedCommitter(address newAuthorizedCommitter) external virtual onlyOwner {
-        require(newAuthorizedCommitter != address(0), EmptyCommitter());
-        _authorizedCommitter = newAuthorizedCommitter;
-        emit AuthorizedCommitterUpdated(newAuthorizedCommitter);
-    }
-
-    /// @inheritdoc ICommitmentStore
-    function commitmentAt(uint256 height) public view virtual returns (bytes32) {
-        return _commitments[height];
-    }
-
-    /// @inheritdoc ICommitmentStore
-    function storeCommitment(uint256 height, bytes32 commitment) external virtual onlyAuthorizedCommitter {
-        _commitments[height] = commitment;
-        emit CommitmentStored(height, commitment);
-    }
-
-    /// @dev Internal helper to validate the authorizedCommitter.
-    function _checkAuthorizedCommitter(address caller) internal view {
-        require(caller == _authorizedCommitter, UnauthorizedCommitter());
+    function storeCommitment(uint256 index, bytes32 commitment) external virtual {
+        _commitments[msg.sender][index] = commitment;
+        emit CommitmentStored(msg.sender, index, commitment);
     }
 }

--- a/src/protocol/ETHBridge.sol
+++ b/src/protocol/ETHBridge.sol
@@ -6,7 +6,7 @@ import {IETHBridge} from "./IETHBridge.sol";
 /// @dev Abstract ETH bridging contract to send native ETH between L1 <-> L2 using storage proofs.
 ///
 /// IMPORTANT: No recovery mechanism is implemented in case an account creates a deposit that can't be claimed.
-abstract contract ETHBridge is IETHBridge {
+contract ETHBridge is IETHBridge {
     mapping(bytes32 id => bool claimed) private _claimed;
 
     /// Incremental nonce to generate unique deposit IDs.
@@ -36,10 +36,12 @@ abstract contract ETHBridge is IETHBridge {
     }
 
     /// @inheritdoc IETHBridge
-    function claimDeposit(ETHDeposit memory deposit, uint256 height, bytes memory proof)
+    function claimDeposit(ETHDeposit memory ethDeposit, uint256 height, bytes memory proof)
         external
-        virtual
-        returns (bytes32 id);
+        returns (bytes32 id)
+    {
+        id = _generateId(ethDeposit);
+    }
 
     /// @dev Processes deposit claim by id.
     /// @param id Identifier of the deposit

--- a/src/protocol/ICheckpointTracker.sol
+++ b/src/protocol/ICheckpointTracker.sol
@@ -8,8 +8,13 @@ interface ICheckpointTracker {
     }
 
     /// @notice Emitted when the proven checkpoint is updated
-    /// @param latestCheckpoint the latest proven checkpoint
-    event CheckpointUpdated(Checkpoint latestCheckpoint);
+    /// @param publicationId the publication ID of the latest proven checkpoint
+    /// @param commitment the commitment of the latest proven checkpoint
+    event CheckpointUpdated(uint256 publicationId, bytes32 commitment);
+
+    /// @dev If genesis is not 0 it should be the latest publication
+    /// @param latestPublicationId the current latest publication ID
+    error GenesisNotLatestPublication(uint256 latestPublicationId);
 
     /// @return _ The last proven checkpoint
     function getProvenCheckpoint() external view returns (Checkpoint memory);

--- a/src/protocol/ICheckpointTracker.sol
+++ b/src/protocol/ICheckpointTracker.sol
@@ -10,11 +10,7 @@ interface ICheckpointTracker {
     /// @notice Emitted when the proven checkpoint is updated
     /// @param publicationId the publication ID of the latest proven checkpoint
     /// @param commitment the commitment of the latest proven checkpoint
-    event CheckpointUpdated(uint256 publicationId, bytes32 commitment);
-
-    /// @dev If genesis is not 0 it should be the latest publication
-    /// @param latestPublicationId the current latest publication ID
-    error GenesisNotLatestPublication(uint256 latestPublicationId);
+    event CheckpointUpdated(uint256 indexed publicationId, bytes32 commitment);
 
     /// @return _ The last proven checkpoint
     function getProvenCheckpoint() external view returns (Checkpoint memory);

--- a/src/protocol/ICommitmentStore.sol
+++ b/src/protocol/ICommitmentStore.sol
@@ -6,22 +6,22 @@ import {ICheckpointTracker} from "./ICheckpointTracker.sol";
 /// @dev Stores commitments from different chains.
 ///
 /// A commitment is any value (typically a state root) that uniquely identifies the state of a chain at a
-/// specific index (i.e. an incremental identifier like a blockNumber, publicationId or even a timestamp).
+/// specific height (i.e. an incremental identifier like a blockNumber, publicationId or even a timestamp).
 ///
 /// There is no access control so only commitments from trusted sources should be used.
 /// For example, L2 contracts should use L1 commitments saved by the anchor contract and L1 contracts should use L2
 /// commitments saved by the relevant `CheckpointTracker`.
 interface ICommitmentStore {
-    /// @dev A new `commitment` has been stored by `source` at a specified `index`.
-    event CommitmentStored(address indexed source, uint256 indexed index, bytes32 commitment);
+    /// @dev A new `commitment` has been stored by `source` at a specified `height`.
+    event CommitmentStored(address indexed source, uint256 indexed height, bytes32 commitment);
 
-    /// @dev Returns the commitment at the given `index`.
+    /// @dev Returns the commitment at the given `height`.
     /// @param source The source address for the saved commitment
-    /// @param index The index of the commitment
-    function commitmentAt(address source, uint256 index) external view returns (bytes32 commitment);
+    /// @param height The height of the commitment
+    function commitmentAt(address source, uint256 height) external view returns (bytes32 commitment);
 
     /// @dev Stores a commitment.
-    /// @param index The index of the commitment
+    /// @param height The height of the commitment
     /// @param commitment The commitment to store
-    function storeCommitment(uint256 index, bytes32 commitment) external;
+    function storeCommitment(uint256 height, bytes32 commitment) external;
 }

--- a/src/protocol/ICommitmentStore.sol
+++ b/src/protocol/ICommitmentStore.sol
@@ -6,36 +6,22 @@ import {ICheckpointTracker} from "./ICheckpointTracker.sol";
 /// @dev Stores commitments from different chains.
 ///
 /// A commitment is any value (typically a state root) that uniquely identifies the state of a chain at a
-/// specific height (i.e. an incremental identifier like a blockNumber, publicationId or even a timestamp).
-/// Only an authorized committer can store commitments. For example, only the `CheckpointTracker` can store roots on the
-/// L1,
-/// and the anchor can store block hashes on the L2.
+/// specific index (i.e. an incremental identifier like a blockNumber, publicationId or even a timestamp).
+///
+/// There is no access control so only commitments from trusted sources should be used.
+/// For example, L2 contracts should use L1 commitments saved by the anchor contract and L1 contracts should use L2
+/// commitments saved by the relevant `CheckpointTracker`.
 interface ICommitmentStore {
-    /// @dev A new `commitment` has been stored at a specified `height`.
-    event CommitmentStored(uint256 indexed height, bytes32 commitment);
+    /// @dev A new `commitment` has been stored by `source` at a specified `index`.
+    event CommitmentStored(address indexed source, uint256 indexed index, bytes32 commitment);
 
-    /// @dev Emitted when the authorized committer is updated.
-    event AuthorizedCommitterUpdated(address newAuthorizedCommitter);
-
-    /// @dev The caller is not a recognized authorized committer.
-    error UnauthorizedCommitter();
-
-    /// @dev The trusted committer address is empty.
-    error EmptyCommitter();
-
-    /// @dev Returns the current authorized committer.
-    function authorizedCommitter() external view returns (address);
-
-    /// @dev Sets a new authorized committer.
-    /// @param newAuthorizedCommitter The new authorized committer address
-    function setAuthorizedCommitter(address newAuthorizedCommitter) external;
-
-    /// @dev Returns the commitment at the given `height`.
-    /// @param height The height of the commitment
-    function commitmentAt(uint256 height) external view returns (bytes32 commitment);
+    /// @dev Returns the commitment at the given `index`.
+    /// @param source The source address for the saved commitment
+    /// @param index The index of the commitment
+    function commitmentAt(address source, uint256 index) external view returns (bytes32 commitment);
 
     /// @dev Stores a commitment.
-    /// @param height The height of the commitment
+    /// @param index The index of the commitment
     /// @param commitment The commitment to store
-    function storeCommitment(uint256 height, bytes32 commitment) external;
+    function storeCommitment(uint256 index, bytes32 commitment) external;
 }

--- a/src/protocol/ICommitmentStore.sol
+++ b/src/protocol/ICommitmentStore.sol
@@ -15,12 +15,13 @@ interface ICommitmentStore {
     /// @dev A new `commitment` has been stored by `source` at a specified `height`.
     event CommitmentStored(address indexed source, uint256 indexed height, bytes32 commitment);
 
-    /// @dev Returns the commitment at the given `height`.
+    /// @notice Returns the commitment at the given `height`.
+    /// @dev If the commitment does not exist at the given `height`, it returns zero.
     /// @param source The source address for the saved commitment
     /// @param height The height of the commitment
     function commitmentAt(address source, uint256 height) external view returns (bytes32 commitment);
 
-    /// @dev Stores a commitment.
+    /// @notice Stores a commitment attributed to `msg.sender`
     /// @param height The height of the commitment
     /// @param commitment The commitment to store
     function storeCommitment(uint256 height, bytes32 commitment) external;

--- a/src/protocol/ISignalService.sol
+++ b/src/protocol/ISignalService.sol
@@ -18,7 +18,7 @@ interface ISignalService {
     /// @param sender The address that sent the signal on the source chain
     /// @param namespace The namespace of the signal
     /// @param value The signal value
-    event SignalSent(address indexed sender, bytes32 namespace, bytes32 value);
+    event SignalSent(address indexed sender, bytes32 indexed namespace, bytes32 value);
 
     /// @dev Emitted when a signal is verified.
     /// @param sender The address of the sender on the source chain
@@ -28,11 +28,11 @@ interface ISignalService {
     /// @dev We require the commitment to contain a state root (with an embedded storage root)
     error StorageRootCommitmentNotSupported();
 
-    /// @dev Stores a data signal and returns its storage location.
+    /// @notice Stores a signal and returns its storage location.
     /// @param value Data to be stored (signalled)
     function sendSignal(bytes32 value) external returns (bytes32 slot);
 
-    /// @dev Checks if a signal has been stored
+    /// @notice Checks if a signal has been stored
     /// @dev Note: This does not mean it has been 'sent' to destination chain,
     /// only that it has been stored on the source chain.
     /// @param value Value to be checked is stored
@@ -40,7 +40,8 @@ interface ISignalService {
     /// @param namespace The namespace of the signal
     function isSignalStored(bytes32 value, address sender, bytes32 namespace) external view returns (bool);
 
-    /// @dev Verifies if the signal can be proved to be part of a merkle tree
+    /// @notice Verifies if the signal can be proved to be part of a merkle tree. This is usually used to verify signals
+    /// sent by `sender` on the source chain, which state is represented by `commitmentPublisher` at `height`.
     /// @dev Signals are not deleted when verified, and can be
     /// verified multiple times by calling this function
     /// @param height This refers to the block number / commitmentId where the trusted root is mapped to

--- a/src/protocol/ISignalService.sol
+++ b/src/protocol/ISignalService.sol
@@ -25,8 +25,8 @@ interface ISignalService {
     /// @param value Value that was signaled
     event SignalVerified(address indexed sender, bytes32 value);
 
-    /// @dev We require a storage proof to be submitted
-    error StateProofNotSupported();
+    /// @dev We require the commitment to contain a state root (with an embedded storage root)
+    error StorageRootCommitmentNotSupported();
 
     /// @dev Stores a data signal and returns its storage location.
     /// @param value Data to be stored (signalled)

--- a/src/protocol/ISignalService.sol
+++ b/src/protocol/ISignalService.sol
@@ -28,6 +28,9 @@ interface ISignalService {
     /// @dev We require the commitment to contain a state root (with an embedded storage root)
     error StorageRootCommitmentNotSupported();
 
+    /// @dev If the commitment returns 0 we assume it does not exist
+    error CommitmentNotFound();
+
     /// @notice Stores a signal and returns its storage location.
     /// @param value Data to be stored (signalled)
     function sendSignal(bytes32 value) external returns (bytes32 slot);
@@ -44,8 +47,9 @@ interface ISignalService {
     /// sent by `sender` on the source chain, which state is represented by `commitmentPublisher` at `height`.
     /// @dev Signals are not deleted when verified, and can be
     /// verified multiple times by calling this function
-    /// @param height This refers to the block number / commitmentId where the trusted root is mapped to
-    /// @param commitmentPublisher The address that published the commitment containing the signal.
+    /// @param height A reference value indicating which trusted root to use for verification
+    /// see ICommitmentStore for more information
+    /// @param commitmentPublisher The address that published the commitment
     /// @param sender The address that originally sent the signal on the source chain
     /// @param value The signal value to verify
     /// @param proof The encoded value of the SignalProof struct

--- a/src/protocol/ISignalService.sol
+++ b/src/protocol/ISignalService.sol
@@ -25,6 +25,9 @@ interface ISignalService {
     /// @param value Value that was signaled
     event SignalVerified(address indexed sender, bytes32 value);
 
+    /// @dev We require a storage proof to be submitted
+    error StateProofNotSupported();
+
     /// @dev Stores a data signal and returns its storage location.
     /// @param value Data to be stored (signalled)
     function sendSignal(bytes32 value) external returns (bytes32 slot);

--- a/src/protocol/ISignalService.sol
+++ b/src/protocol/ISignalService.sol
@@ -44,8 +44,15 @@ interface ISignalService {
     /// @dev Signals are not deleted when verified, and can be
     /// verified multiple times by calling this function
     /// @param height This refers to the block number / commitmentId where the trusted root is mapped to
+    /// @param commitmentPublisher The address that published the commitment containing the signal.
     /// @param sender The address that originally sent the signal on the source chain
     /// @param value The signal value to verify
     /// @param proof The encoded value of the SignalProof struct
-    function verifySignal(uint256 height, address sender, bytes32 value, bytes memory proof) external;
+    function verifySignal(
+        uint256 height,
+        address commitmentPublisher,
+        address sender,
+        bytes32 value,
+        bytes memory proof
+    ) external;
 }

--- a/src/protocol/SignalService.sol
+++ b/src/protocol/SignalService.sol
@@ -10,15 +10,12 @@ import {ISignalService} from "./ISignalService.sol";
 ///
 /// This contract allows sending arbitrary data as signals via `sendSignal`, verifying signals from other chains using
 /// `verifySignal`, and bridging native ETH with built-in signal generation and verification. It integrates:
-/// - `CommitmentStore` to access trusted state roots,
-/// - `ETHBridge` for native ETH bridging with deposit and claim flows,
+/// - `CommitmentStore` to access state roots,
 /// - `LibSignal` for signal hashing, storage, and verification logic.
 ///
 /// Signals stored cannot be deleted and can be verified multiple times.
-contract SignalService is ISignalService, ETHBridge, CommitmentStore {
+contract SignalService is ISignalService, CommitmentStore {
     using LibSignal for bytes32;
-
-    constructor(address _rollupOperator) CommitmentStore(_rollupOperator) {}
 
     /// @inheritdoc ISignalService
     /// @dev Signals are stored in a namespaced slot derived from the signal value, sender address and SIGNAL_NAMESPACE
@@ -36,8 +33,10 @@ contract SignalService is ISignalService, ETHBridge, CommitmentStore {
 
     /// @inheritdoc ISignalService
     /// @dev Cannot be used to verify signals that are under the eth-bridge namespace.
-    function verifySignal(uint256 height, address sender, bytes32 value, bytes memory proof) external {
-        _verifySignal(height, sender, value, LibSignal.SIGNAL_NAMESPACE, proof);
+    function verifySignal(uint256 index, address commitmentPublisher, address sender, bytes32 value, bytes memory proof)
+        external
+    {
+        _verifySignal(index, commitmentPublisher, sender, value, LibSignal.SIGNAL_NAMESPACE, proof);
         emit SignalVerified(sender, value);
     }
 
@@ -50,27 +49,30 @@ contract SignalService is ISignalService, ETHBridge, CommitmentStore {
     // CHECK: Should this function be non-reentrant?
     /// @inheritdoc ETHBridge
     /// @dev Overrides ETHBridge.claimDeposit to add signal verification logic.
-    function claimDeposit(ETHDeposit memory ethDeposit, uint256 height, bytes memory proof)
+    function claimDeposit(ETHDeposit memory ethDeposit, uint256 index, bytes memory proof)
         external
         override
         returns (bytes32 id)
     {
         id = _generateId(ethDeposit);
 
-        _verifySignal(height, ethDeposit.from, id, ETH_BRIDGE_NAMESPACE, proof);
+        _verifySignal(index, commitmentPublisher, ethDeposit.from, id, ETH_BRIDGE_NAMESPACE, proof);
 
         super._processClaimDepositWithId(id, ethDeposit);
     }
 
-    function _verifySignal(uint256 height, address sender, bytes32 value, bytes32 namespace, bytes memory proof)
-        internal
-        view
-        virtual
-    {
+    function _verifySignal(
+        uint256 index,
+        address commitmentPublisher,
+        address sender,
+        bytes32 value,
+        bytes32 namespace,
+        bytes memory proof
+    ) internal view virtual {
         // TODO: commitmentAt(height) might not be the 'state root' of the chain
         // For now it could be the block hash or other hashed value
         // further work is needed to ensure we get the 'state root' of the chain
-        bytes32 root = commitmentAt(height);
+        bytes32 root = commitmentAt(commitmentPublisher, index);
         SignalProof memory signalProof = abi.decode(proof, (SignalProof));
         bytes[] memory accountProof = signalProof.accountProof;
         bytes[] memory storageProof = signalProof.storageProof;

--- a/src/protocol/SignalService.sol
+++ b/src/protocol/SignalService.sol
@@ -62,8 +62,8 @@ contract SignalService is ISignalService, CommitmentStore {
         bytes[] memory accountProof = signalProof.accountProof;
         bytes[] memory storageProof = signalProof.storageProof;
         // if there is no account proof, verify signal will treat root as a storage root
-        // instead of a full state root which we currently do not support
-        require(accountProof.length != 0, StateProofNotSupported());
+        // for now, we only support full state roots
+        require(accountProof.length != 0, StorageRootCommitmentNotSupported());
         value.verifySignal(namespace, sender, root, accountProof, storageProof);
     }
 }

--- a/src/protocol/SignalService.sol
+++ b/src/protocol/SignalService.sol
@@ -8,14 +8,16 @@ import {ETHBridge} from "./ETHBridge.sol";
 import {ICommitmentStore} from "./ICommitmentStore.sol";
 import {ISignalService} from "./ISignalService.sol";
 
-/// @dev SignalService combines secure cross-chain messaging with native token bridging.
+/// @dev SignalService is used for secure cross-chain messaging
 ///
-/// This contract allows sending arbitrary data as signals via `sendSignal`, verifying signals from other chains using
-/// `verifySignal`, and bridging native ETH with built-in signal generation and verification. It integrates:
-/// - `CommitmentStore` to access state roots,
-/// - `LibSignal` for signal hashing, storage, and verification logic.
+/// This contract allows sending arbitrary data as signals via `sendSignal` and verifying signals from other chains
+/// using`verifySignal`
+///   It integrates:
+///    - `CommitmentStore` to access state roots,
+///    - `LibSignal` for signal hashing, storage, and verification logic.
 ///
-/// Signals stored cannot be deleted and can be verified multiple times.
+/// Signals stored cannot be deleted
+/// WARN: this contract does not provide replay protection(signals can be verified multiple times).
 contract SignalService is ISignalService, CommitmentStore {
     using LibSignal for bytes32;
 
@@ -58,12 +60,20 @@ contract SignalService is ISignalService, CommitmentStore {
         // For now it could be the block hash or other hashed value
         // further work is needed to ensure we get the 'state root' of the chain
         bytes32 root = commitmentAt(commitmentPublisher, height);
+
+        // A 0 root would probably fail further down the line but its better to explicitly check
+        require(root != 0, CommitmentNotFound());
+
         SignalProof memory signalProof = abi.decode(proof, (SignalProof));
         bytes[] memory accountProof = signalProof.accountProof;
         bytes[] memory storageProof = signalProof.storageProof;
-        // if there is no account proof, verify signal will treat root as a storage root
-        // for now, we only support full state roots
+
+        // We only support state roots for verification
+        // this is to avoid state roots being used as storage roots (for safety)
         require(accountProof.length != 0, StorageRootCommitmentNotSupported());
-        value.verifySignal(namespace, sender, root, accountProof, storageProof);
+
+        value.verifySignal(sender, root, accountProof, storageProof);
+
+        emit SignalVerified(sender, value);
     }
 }

--- a/src/protocol/SignalService.sol
+++ b/src/protocol/SignalService.sol
@@ -55,7 +55,7 @@ contract SignalService is ISignalService, CommitmentStore {
         bytes32 value,
         bytes32 namespace,
         bytes memory proof
-    ) internal view virtual {
+    ) internal virtual {
         // TODO: commitmentAt(height) might not be the 'state root' of the chain
         // For now it could be the block hash or other hashed value
         // further work is needed to ensure we get the 'state root' of the chain
@@ -72,7 +72,7 @@ contract SignalService is ISignalService, CommitmentStore {
         // this is to avoid state roots being used as storage roots (for safety)
         require(accountProof.length != 0, StorageRootCommitmentNotSupported());
 
-        value.verifySignal(sender, root, accountProof, storageProof);
+        value.verifySignal(namespace, sender, root, accountProof, storageProof);
 
         emit SignalVerified(sender, value);
     }

--- a/src/protocol/taiko_alethia/TaikoAnchor.sol
+++ b/src/protocol/taiko_alethia/TaikoAnchor.sol
@@ -15,7 +15,6 @@ contract TaikoAnchor {
     uint256 public lastPublicationId;
     bytes32 public circularBlocksHash;
     mapping(uint256 blockId => bytes32 blockHash) public blockHashes;
-    mapping(uint256 blockId => bytes32 blockHash) public l1BlockHashes;
 
     modifier onlyFromPermittedSender() {
         require(msg.sender == permittedSender, "sender not golden touch");
@@ -61,7 +60,6 @@ contract TaikoAnchor {
         // Persist anchor block hashes
         if (_anchorBlockId > lastAnchorBlockId) {
             lastAnchorBlockId = _anchorBlockId;
-            l1BlockHashes[_anchorBlockId] = _anchorBlockHash;
             // Stores the state of the other chain
             commitmentStore.storeCommitment(_anchorBlockId, _anchorBlockHash);
         }
@@ -78,6 +76,10 @@ contract TaikoAnchor {
         _verifyBaseFee(_parentGasUsed);
 
         emit Anchor(_publicationId, _anchorBlockId, _anchorBlockHash, _parentGasUsed);
+    }
+
+    function l1BlockHashes(uint256 blockId) external view returns (bytes32 blockHash) {
+        return commitmentStore.commitmentAt(address(this), blockId);
     }
 
     /// @dev Calculates the aggregated ancestor block hash for the given block ID

--- a/test/CheckpointTracker.t.sol
+++ b/test/CheckpointTracker.t.sol
@@ -36,13 +36,12 @@ contract CheckpointTrackerTest is Test {
         feed = new PublicationFeed();
         createSampleFeed();
 
-        signalService = new SignalService(rollupOperator);
+        signalService = new SignalService();
 
         tracker = new CheckpointTracker(
             keccak256(abi.encode("genesis")), address(feed), address(verifier), proverManager, address(signalService)
         );
         vm.prank(rollupOperator);
-        ICommitmentStore(address(signalService)).setAuthorizedCommitter(address(tracker));
         proof = abi.encode("proof");
     }
 

--- a/test/ProverManager.t.sol
+++ b/test/ProverManager.t.sol
@@ -8,17 +8,17 @@ import {ProverManager} from "../src/protocol/taiko_alethia/ProverManager.sol";
 import {ICheckpointTracker} from "src/protocol/ICheckpointTracker.sol";
 import {IPublicationFeed} from "src/protocol/IPublicationFeed.sol";
 import {PublicationFeed} from "src/protocol/PublicationFeed.sol";
-import {SignalService} from "src/protocol/SignalService.sol";
 
+import {SignalService} from "src/protocol/SignalService.sol";
 import {MockCheckpointTracker} from "test/mocks/MockCheckpointTracker.sol";
 import {NullVerifier} from "test/mocks/NullVerifier.sol";
 
 contract ProverManagerTest is Test {
     ProverManager proverManager;
     MockCheckpointTracker checkpointTracker;
+    SignalService signalService;
     NullVerifier verifier;
     PublicationFeed publicationFeed;
-    SignalService signalService;
     uint256 constant DEPOSIT_AMOUNT = 2 ether;
 
     // Addresses used for testing.
@@ -43,11 +43,9 @@ contract ProverManagerTest is Test {
     uint256 constant INITIAL_PERIOD = 1;
 
     function setUp() public {
-        signalService = new SignalService(rollupOperator);
-        checkpointTracker = new MockCheckpointTracker(address(signalService));
         publicationFeed = new PublicationFeed();
-        vm.prank(rollupOperator);
-        signalService.setAuthorizedCommitter(address(checkpointTracker));
+        signalService = new SignalService();
+        checkpointTracker = new MockCheckpointTracker(address(signalService));
 
         // Fund the initial prover so the constructor can receive the required livenessBond.
         vm.deal(initialProver, 10 ether);

--- a/test/signal/SignalService.t.sol
+++ b/test/signal/SignalService.t.sol
@@ -48,7 +48,7 @@ contract BaseState is Test {
         vm.deal(defaultSender, senderBalanceL1);
 
         vm.prank(defaultSender);
-        L1signalService = new SignalService(rollupOperator);
+        L1signalService = new SignalService();
         vm.deal(address(L1signalService), ETHBridgeInitBalance);
 
         checkpointTracker = new MockCheckpointTracker(address(L1signalService));
@@ -60,13 +60,10 @@ contract BaseState is Test {
         vm.deal(defaultSender, senderBalanceL2);
 
         vm.prank(defaultSender);
-        L2signalService = new SignalService(rollupOperator);
+        L2signalService = new SignalService();
         vm.deal(address(L2signalService), ETHBridgeInitBalance);
 
         anchor = new MockAnchor(address(L2signalService));
-
-        vm.prank(rollupOperator);
-        L2signalService.setAuthorizedCommitter(address(anchor));
 
         // Labels for debugging
         vm.label(address(L1signalService), "L1signalService");
@@ -132,7 +129,7 @@ contract SendL1SignalTest is SendL1SignalState {
         uint256 height = 1;
         anchor.anchor(height, stateRoot);
 
-        L2signalService.verifySignal(height, defaultSender, signal, encodedProof);
+        L2signalService.verifySignal(height, address(anchor), defaultSender, signal, encodedProof);
     }
 
     function test_verifyL1Signal_UsingStorageProof() public {
@@ -145,6 +142,6 @@ contract SendL1SignalTest is SendL1SignalState {
         uint256 height = 1;
         anchor.anchor(height, storageRoot);
 
-        L2signalService.verifySignal(height, defaultSender, signal, encodedProof);
+        L2signalService.verifySignal(height, address(anchor), defaultSender, signal, encodedProof);
     }
 }


### PR DESCRIPTION
Currently this PR address these points:

- [x] Avoid duplicate checkpoints. The TaikoAnchor and CheckpointTracker now use the signal service for their checkpoint/l1blocks storage.
- [x] Remove commitment access control. Anyone can post commitments, which are saved under the source address. Access control can be achieved on the recipient end (they should only use checkpoints saved by a valid address). 
- [x]  Allow the CheckpointTracker genesis to start the current publication ID.
