### PR TITLE
Use two decimals for delayed scale factor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ env:
 
 jobs:
   check:
-    strategy:
-      fail-fast: true
-
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +20,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Show Forge version
         run: |

--- a/src/libs/LibPercentage.sol
+++ b/src/libs/LibPercentage.sol
@@ -7,7 +7,7 @@ library LibPercentage {
     using SafeCast for uint256;
 
     // COMMON PRECISION AMOUNTS (https://muens.io/solidity-percentages)
-    uint256 constant BASIS_POINTS = 10000;
+    uint256 constant BASIS_POINTS = 10_000;
     uint256 constant PERCENT = 100;
 
     /// @dev Calculates the percentage of a given value scaling by `precision` to limit rounding loss

--- a/src/libs/LibPercentage.sol
+++ b/src/libs/LibPercentage.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+library LibPercentage {
+    using SafeCast for uint256;
+
+    // COMMON PRECISION AMOUNTS (https://muens.io/solidity-percentages)
+    uint256 constant BASIS_POINTS = 10000;
+    uint256 constant TWO_DECIMALS = 100;
+
+    /// @dev Calculates the percentage of a given value scaling by `precision` to limit rounding loss
+    /// @param value The number to scale
+    /// @param percentage The percentage expressed in `precision` units.
+    /// @param precision The precision of `percentage` (e.g. percentage 5000 with BASIS_POINTS precision is 50%).
+    /// @return _ The scaled value
+    function scaleBy(uint256 value, uint16 percentage, uint256 precision) internal pure returns (uint96) {
+        return (value * percentage / precision).toUint96();
+    }
+
+    /// @dev Calculates the percentage (represented in basis points) of a given value
+    /// @param value The number to scale
+    /// @param percentage The percentage expressed in basis points
+    /// @return _ The scaled value
+    function scaleBy(uint256 value, uint16 percentage) internal pure returns (uint96) {
+        return scaleBy(value, percentage, BASIS_POINTS);
+    }
+}

--- a/src/libs/LibPercentage.sol
+++ b/src/libs/LibPercentage.sol
@@ -8,7 +8,7 @@ library LibPercentage {
 
     // COMMON PRECISION AMOUNTS (https://muens.io/solidity-percentages)
     uint256 constant BASIS_POINTS = 10000;
-    uint256 constant TWO_DECIMALS = 100;
+    uint256 constant PERCENT = 100;
 
     /// @dev Calculates the percentage of a given value scaling by `precision` to limit rounding loss
     /// @param value The number to scale

--- a/src/libs/LibPercentage.sol
+++ b/src/libs/LibPercentage.sol
@@ -23,7 +23,15 @@ library LibPercentage {
     /// @param value The number to scale
     /// @param percentage The percentage expressed in basis points
     /// @return _ The scaled value
-    function scaleBy(uint256 value, uint16 percentage) internal pure returns (uint96) {
+    function scaleByBPS(uint256 value, uint16 percentage) internal pure returns (uint96) {
+        return scaleBy(value, percentage, BASIS_POINTS);
+    }
+
+    /// @dev Calculates the percentage of a given value
+    /// @param value The number to scale
+    /// @param percentage The percentage to single-percentage precision (e.g. percentage 50 is 50%)
+    /// @return _ The scaled value
+    function scaleByPercentage(uint256 value, uint16 percentage) internal pure returns (uint96) {
         return scaleBy(value, percentage, BASIS_POINTS);
     }
 }

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -98,7 +98,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         // Deduct fee from proposer's balance
         uint96 fee = _periods[periodId].fee;
         if (isDelayed) {
-            fee = fee.scaleBy(_periods[periodId].delayedFeePercentage, LibPercentage.PERCENT);
+            fee = fee.scaleByPercentage(_periods[periodId].delayedFeePercentage);
         }
         _balances[proposer] -= fee;
     }
@@ -151,7 +151,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         (uint40 end,) = _closePeriod(period, _exitDelay(), 0);
 
         // Reward the evictor and slash the prover
-        uint96 evictorIncentive = period.stake.scaleBy(_evictorIncentivePercentage());
+        uint96 evictorIncentive = period.stake.scaleByBPS(_evictorIncentivePercentage());
         _balances[msg.sender] += evictorIncentive;
         period.stake -= evictorIncentive;
 
@@ -213,7 +213,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         uint256 delayedPubFee;
 
         if (numDelayedPublications > 0) {
-            uint96 delayedFee = baseFee.scaleBy(period.delayedFeePercentage, LibPercentage.PERCENT);
+            uint96 delayedFee = baseFee.scaleByPercentage(period.delayedFeePercentage);
             delayedPubFee = numDelayedPublications * delayedFee;
         }
 
@@ -232,7 +232,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         require(provenPublication.timestamp > period.end, "Publication must be after period");
 
         uint96 stake = period.stake;
-        _balances[period.prover] += period.pastDeadline ? stake.scaleBy(_rewardPercentage()) : stake;
+        _balances[period.prover] += period.pastDeadline ? stake.scaleByBPS(_rewardPercentage()) : stake;
         period.stake = 0;
     }
 
@@ -249,7 +249,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
 
         Period storage period = _periods[currentPeriod];
         fee = period.fee;
-        delayedFee = fee.scaleBy(period.delayedFeePercentage, LibPercentage.PERCENT);
+        delayedFee = fee.scaleByPercentage(period.delayedFeePercentage);
     }
 
     /// @notice Get the balance of a user
@@ -276,7 +276,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
     /// @param fee The fee to be outbid (either the current period's fee or next period's winning fee)
     /// @param offeredFee The new bid
     function _ensureSufficientUnderbid(uint96 fee, uint96 offeredFee) internal view virtual {
-        uint96 requiredMaxFee = fee.scaleBy(_maxBidPercentage());
+        uint96 requiredMaxFee = fee.scaleByBPS(_maxBidPercentage());
         require(offeredFee <= requiredMaxFee, "Offered fee not low enough");
     }
 

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -9,7 +9,6 @@ import {IPublicationFeed} from "./IPublicationFeed.sol";
 
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
-
 abstract contract BaseProverManager is IProposerFees, IProverManager {
     using SafeCast for uint256;
     using LibPercentage for uint96;

--- a/test/BaseProverManager.t.sol
+++ b/test/BaseProverManager.t.sol
@@ -11,9 +11,9 @@ import {ICheckpointTracker} from "src/protocol/ICheckpointTracker.sol";
 import {IPublicationFeed} from "src/protocol/IPublicationFeed.sol";
 import {PublicationFeed} from "src/protocol/PublicationFeed.sol";
 
+import {LibPercentage} from "src/libs/LibPercentage.sol";
 import {MockCheckpointTracker} from "test/mocks/MockCheckpointTracker.sol";
 import {NullVerifier} from "test/mocks/NullVerifier.sol";
-import {LibPercentage} from "src/libs/LibPercentage.sol";
 
 // Configuration parameters.
 uint16 constant MAX_BID_PERCENTAGE = 9500; // 95%
@@ -943,8 +943,9 @@ abstract contract BaseProverManagerTest is Test {
         internal
         returns (IPublicationFeed.PublicationHeader[] memory)
     {
-        uint256 depositAmount =
-            delayed ? LibPercentage.scaleByPercentage(fee, DELAYED_FEE_PERCENTAGE) * numPublications : fee * numPublications;
+        uint256 depositAmount = delayed
+            ? LibPercentage.scaleByPercentage(fee, DELAYED_FEE_PERCENTAGE) * numPublications
+            : fee * numPublications;
         _deposit(proposer, depositAmount);
 
         IPublicationFeed.PublicationHeader[] memory headers = new IPublicationFeed.PublicationHeader[](numPublications);
@@ -977,6 +978,7 @@ abstract contract BaseProverManagerTest is Test {
     function _maxAllowedFee(uint96 fee) internal pure returns (uint96) {
         return uint96(LibPercentage.scaleByBPS(fee, MAX_BID_PERCENTAGE));
     }
+
     function _exit(address prover) internal {
         vm.prank(prover);
         proverManager.exit();

--- a/test/BaseProverManager.t.sol
+++ b/test/BaseProverManager.t.sol
@@ -13,6 +13,7 @@ import {PublicationFeed} from "src/protocol/PublicationFeed.sol";
 
 import {MockCheckpointTracker} from "test/mocks/MockCheckpointTracker.sol";
 import {NullVerifier} from "test/mocks/NullVerifier.sol";
+import {LibPercentage} from "src/libs/LibPercentage.sol";
 
 // Configuration parameters.
 uint16 constant MAX_BID_PERCENTAGE = 9500; // 95%
@@ -218,7 +219,7 @@ abstract contract BaseProverManagerTest is Test {
         // Capture current period stake before eviction
         BaseProverManager.Period memory periodBefore = proverManager.getPeriod(1);
         uint256 stakeBefore = periodBefore.stake;
-        uint256 incentive = _calculatePercentageBPS(stakeBefore, EVICTOR_INCENTIVE_PERCENTAGE);
+        uint256 incentive = LibPercentage.scaleByBPS(stakeBefore, EVICTOR_INCENTIVE_PERCENTAGE);
 
         // Evict the prover
         vm.warp(vm.getBlockTimestamp() + LIVENESS_WINDOW + 1);
@@ -504,7 +505,7 @@ abstract contract BaseProverManagerTest is Test {
 
         uint256 proverBalanceAfter = proverManager.balances(initialProver);
         uint256 expectedBalance = proverBalanceBefore + INITIAL_FEE * numRegularPublications
-            + _calculatePercentage(INITIAL_FEE, DELAYED_FEE_PERCENTAGE) * numDelayedPublications;
+            + LibPercentage.scaleByPercentage(INITIAL_FEE, DELAYED_FEE_PERCENTAGE) * numDelayedPublications;
         assertEq(proverBalanceAfter, expectedBalance, "Prover should receive fees");
     }
 
@@ -848,7 +849,7 @@ abstract contract BaseProverManagerTest is Test {
 
         uint256 initialProverBalanceAfter = proverManager.balances(initialProver);
         uint256 prover1BalanceAfter = proverManager.balances(prover1);
-        uint256 stakeReward = _calculatePercentageBPS(stakeBefore, REWARD_PERCENTAGE);
+        uint256 stakeReward = LibPercentage.scaleByBPS(stakeBefore, REWARD_PERCENTAGE);
         assertEq(prover1BalanceAfter, prover1BalanceBefore + stakeReward, "Prover1 should receive the remaining stake");
         assertEq(initialProverBalanceAfter, initialProverBalanceBefore, "Initial prover should receive nothing");
     }
@@ -905,7 +906,7 @@ abstract contract BaseProverManagerTest is Test {
         assertEq(fee, INITIAL_FEE, "Fee should be the initial fee");
         assertEq(
             delayedFee,
-            _calculatePercentage(INITIAL_FEE, DELAYED_FEE_PERCENTAGE),
+            LibPercentage.scaleByPercentage(INITIAL_FEE, DELAYED_FEE_PERCENTAGE),
             "Delayed fee should be the initial fee"
         );
     }
@@ -926,7 +927,7 @@ abstract contract BaseProverManagerTest is Test {
         assertEq(fee, bidFee, "Fee should be the bid fee");
         assertEq(
             delayedFee,
-            uint96(_calculatePercentage(bidFee, DELAYED_FEE_PERCENTAGE)),
+            uint96(LibPercentage.scaleByPercentage(bidFee, DELAYED_FEE_PERCENTAGE)),
             "Delayed fee should be the bid fee"
         );
     }
@@ -943,7 +944,7 @@ abstract contract BaseProverManagerTest is Test {
         returns (IPublicationFeed.PublicationHeader[] memory)
     {
         uint256 depositAmount =
-            delayed ? _calculatePercentage(fee, DELAYED_FEE_PERCENTAGE) * numPublications : fee * numPublications;
+            delayed ? LibPercentage.scaleByPercentage(fee, DELAYED_FEE_PERCENTAGE) * numPublications : fee * numPublications;
         _deposit(proposer, depositAmount);
 
         IPublicationFeed.PublicationHeader[] memory headers = new IPublicationFeed.PublicationHeader[](numPublications);
@@ -974,18 +975,8 @@ abstract contract BaseProverManagerTest is Test {
     function _deposit(address user, uint256 amount) internal virtual;
 
     function _maxAllowedFee(uint96 fee) internal pure returns (uint96) {
-        return uint96(_calculatePercentageBPS(fee, MAX_BID_PERCENTAGE));
+        return uint96(LibPercentage.scaleByBPS(fee, MAX_BID_PERCENTAGE));
     }
-
-    function _calculatePercentageBPS(uint256 amount, uint16 percentage) internal pure returns (uint256) {
-        return amount * percentage / 10_000;
-    }
-
-    function _calculatePercentage(uint256 amount, uint16 percentage) internal pure returns (uint256) {
-        return amount * percentage / 100;
-    }
-
-
     function _exit(address prover) internal {
         vm.prank(prover);
         proverManager.exit();

--- a/test/BaseProverManager.t.sol
+++ b/test/BaseProverManager.t.sol
@@ -24,7 +24,7 @@ uint96 constant LIVENESS_BOND = 1 ether;
 uint16 constant EVICTOR_INCENTIVE_PERCENTAGE = 500; // 5%
 uint16 constant REWARD_PERCENTAGE = 9000; // 90%
 uint96 constant INITIAL_FEE = 0.1 ether;
-uint16 constant DELAYED_FEE_PERCENTAGE = 15_000; // 150%
+uint16 constant DELAYED_FEE_PERCENTAGE = 150; // 150%
 uint256 constant INITIAL_PERIOD = 1;
 
 abstract contract BaseProverManagerTest is Test {
@@ -218,7 +218,7 @@ abstract contract BaseProverManagerTest is Test {
         // Capture current period stake before eviction
         BaseProverManager.Period memory periodBefore = proverManager.getPeriod(1);
         uint256 stakeBefore = periodBefore.stake;
-        uint256 incentive = _calculatePercentage(stakeBefore, EVICTOR_INCENTIVE_PERCENTAGE);
+        uint256 incentive = _calculatePercentageBPS(stakeBefore, EVICTOR_INCENTIVE_PERCENTAGE);
 
         // Evict the prover
         vm.warp(vm.getBlockTimestamp() + LIVENESS_WINDOW + 1);
@@ -848,7 +848,7 @@ abstract contract BaseProverManagerTest is Test {
 
         uint256 initialProverBalanceAfter = proverManager.balances(initialProver);
         uint256 prover1BalanceAfter = proverManager.balances(prover1);
-        uint256 stakeReward = _calculatePercentage(stakeBefore, REWARD_PERCENTAGE);
+        uint256 stakeReward = _calculatePercentageBPS(stakeBefore, REWARD_PERCENTAGE);
         assertEq(prover1BalanceAfter, prover1BalanceBefore + stakeReward, "Prover1 should receive the remaining stake");
         assertEq(initialProverBalanceAfter, initialProverBalanceBefore, "Initial prover should receive nothing");
     }
@@ -974,12 +974,17 @@ abstract contract BaseProverManagerTest is Test {
     function _deposit(address user, uint256 amount) internal virtual;
 
     function _maxAllowedFee(uint96 fee) internal pure returns (uint96) {
-        return uint96(_calculatePercentage(fee, MAX_BID_PERCENTAGE));
+        return uint96(_calculatePercentageBPS(fee, MAX_BID_PERCENTAGE));
+    }
+
+    function _calculatePercentageBPS(uint256 amount, uint16 percentage) internal pure returns (uint256) {
+        return amount * percentage / 10_000;
     }
 
     function _calculatePercentage(uint256 amount, uint16 percentage) internal pure returns (uint256) {
-        return amount * percentage / 10_000;
+        return amount * percentage / 100;
     }
+
 
     function _exit(address prover) internal {
         vm.prank(prover);


### PR DESCRIPTION
This PR make two changes.

Firstly, move the percentage calculations to a separate library. This is cleaner in code and it also makes it easier to use different precision amounts.

The second is to use two decimals of precision for the delayed fee percentage. As a uint16 there are 65536 possible values but in basis points we can only represent numbers between 0 and 6.5 (albeit with very high precision). With two decimals we can represent numbers up to 655 (with less precision).
