### PR TITLE
Proving Period Library

### DIFF
--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.28;
 import {LibPercentage} from "../libs/LibPercentage.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
-
 /// Each proving period is defined by
 /// - the _prover_ address that must post proofs for any publications received during this period
 /// - the standard proving _fee_ that the prover charges per publication in this period
@@ -38,6 +37,18 @@ library LibProvingPeriod {
         uint40 deadline;
         // whether the final proof came after the deadline
         bool pastDeadline;
+    }
+
+    /// @notice Initializes the period with the given parameters.
+    /// @dev The _end_ and _deadline_ default to zero. The _pastDeadline` flag defaults to false.
+    /// @dev This can be called multiple times to set the latest bid while the auction is ongoing.
+    function init(Period storage period, address prover, uint96 fee, uint16 delayedFeePercentage, uint96 stake)
+        internal
+    {
+        period.prover = prover;
+        period.fee = fee;
+        period.delayedFeePercentage = delayedFeePercentage;
+        period.stake = stake;
     }
 
     /// @notice The period has an end timestamp in the past

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -87,6 +87,10 @@ library LibProvingPeriod {
         return block.timestamp > period.deadline && period.deadline != 0;
     }
 
+    function isVacant(Period storage period) internal view returns (bool) {
+        return !isInitialized(period) && isOpen(period);
+    }
+
     function totalFeeEarned(Period storage period, uint256 numPublications, uint256 numDelayedPublications)
         internal
         view

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -45,6 +45,7 @@ library LibProvingPeriod {
     function init(Period storage period, address prover, uint96 fee, uint16 delayedFeePercentage, uint96 stake)
         internal
     {
+        require(prover != address(0), "Prover cannot be zero address");
         period.prover = prover;
         period.fee = fee;
         period.delayedFeePercentage = delayedFeePercentage;

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -52,6 +52,11 @@ library LibProvingPeriod {
         period.stake = stake;
     }
 
+    /// @notice Whether the period has been initialized
+    function isInitialized(Period storage period) internal view returns (bool) {
+        return period.prover != address(0);
+    }
+
     /// @notice The period has an end timestamp in the past
     function isComplete(Period storage period) internal view returns (bool) {
         uint40 periodEnd = period.end;

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -83,6 +83,16 @@ library LibProvingPeriod {
         return block.timestamp > period.deadline && period.deadline != 0;
     }
 
+    function totalFeeEarned(Period storage period, uint256 numPublications, uint256 numDelayedPublications)
+        internal
+        view
+        returns (uint96)
+    {
+        uint256 standardFee = publicationFee(period, false) * (numPublications - numDelayedPublications);
+        uint256 delayedFee = publicationFee(period, true) * numDelayedPublications;
+        return (standardFee + delayedFee).toUint96();
+    }
+
     /// @dev Sets the period's end and deadline timestamps
     /// @param period The period to finalize
     /// @param endDelay The duration (from now) when the period will end

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -103,4 +103,12 @@ library LibProvingPeriod {
     function slash(Period storage period, uint96 penalty) internal {
         period.stake -= penalty;
     }
+
+    /// @notice Assign the newProver (and percentage of remaining stake) to the new prover
+    /// @dev The last prover for the period will be assigned the reward (claimed with `finalizePastPeriod`).
+    /// In practice, a single prover will likely close the whole period with one proof.
+    function assignReward(Period storage period, address newProver) internal {
+        period.prover = newProver;
+        period.pastDeadline = true;
+    }
 }

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -88,4 +88,9 @@ library LibProvingPeriod {
         period.end = end;
         period.deadline = deadline;
     }
+
+    /// @notice slash the penalty from the period's stake
+    function slash(Period storage period, uint96 penalty) internal {
+        period.stake -= penalty;
+    }
 }

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -32,4 +32,10 @@ library LibProvingPeriod {
         // whether the proof came after the deadline
         bool pastDeadline;
     }
+
+    /// @notice The period has an end timestamp in the past
+    function isComplete(Period storage period) internal view returns (bool) {
+        uint40 periodEnd = period.end;
+        return periodEnd != 0 && block.timestamp > periodEnd;
+    }
 }

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -125,4 +125,13 @@ library LibProvingPeriod {
         period.prover = newProver;
         period.pastDeadline = true;
     }
+
+    /// @notice Reset the prover and stake to zero. This ensures it cannot be finalized again.
+    /// @return stakeToReturn The amount of stake to return to the prover. If the original prover missed a proving
+    /// deadline, this will be just the reward percentage. The rest of the funds are locked in the contract.
+    function finalize(Period storage period, uint16 rewardPercentage) internal returns (uint96 stakeToReturn) {
+        stakeToReturn = period.pastDeadline ? period.stake.scaleBy(rewardPercentage) : period.stake;
+        period.prover = address(0);
+        period.stake = 0;
+    }
 }

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -47,4 +47,9 @@ library LibProvingPeriod {
     function publicationFee(Period storage period, bool isDelayed) internal view returns (uint96) {
         return isDelayed ? period.fee.scaleBy(period.delayedFeePercentage, LibPercentage.PERCENT) : period.fee;
     }
+
+    /// @notice The period has no end timestamp
+    function isOpen(Period storage period) internal view returns (bool) {
+        return period.end == 0;
+    }
 }

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -73,6 +73,11 @@ library LibProvingPeriod {
         return period.end == 0;
     }
 
+    /// @notice The timestamp is not after the end of the period
+    function isNotBefore(Period storage period, uint256 timestamp) internal view returns (bool) {
+        return isOpen(period) || timestamp.toUint40() <= period.end;
+    }
+
     /// @dev Sets the period's end and deadline timestamps
     /// @param period The period to finalize
     /// @param endDelay The duration (from now) when the period will end

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -59,8 +59,7 @@ library LibProvingPeriod {
 
     /// @notice The period has an end timestamp in the past
     function isComplete(Period storage period) internal view returns (bool) {
-        uint40 periodEnd = period.end;
-        return periodEnd != 0 && block.timestamp > periodEnd;
+        return isBefore(period, block.timestamp);
     }
 
     /// @notice The period fee, scaled by `delayedFeePercentage` if the publication is delayed
@@ -73,9 +72,14 @@ library LibProvingPeriod {
         return period.end == 0;
     }
 
+    /// @notice The timestamp is after the end of the period (which must be set)
+    function isBefore(Period storage period, uint256 timestamp) internal view returns (bool) {
+        return period.end != 0 && timestamp > period.end;
+    }
+
     /// @notice The timestamp is not after the end of the period
     function isNotBefore(Period storage period, uint256 timestamp) internal view returns (bool) {
-        return isOpen(period) || timestamp.toUint40() <= period.end;
+        return !isBefore(period, timestamp);
     }
 
     /// @notice The period has a deadline timestamp in the past

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -78,6 +78,11 @@ library LibProvingPeriod {
         return isOpen(period) || timestamp.toUint40() <= period.end;
     }
 
+    /// @notice The period has a deadline timestamp in the past
+    function isDeadlinePassed(Period storage period) internal view returns (bool) {
+        return block.timestamp > period.deadline && period.deadline != 0;
+    }
+
     /// @dev Sets the period's end and deadline timestamps
     /// @param period The period to finalize
     /// @param endDelay The duration (from now) when the period will end

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+library LibProvingPeriod {
+    struct Period {
+        // SLOT 1
+        address prover;
+        uint96 stake;
+        // SLOT 2
+        // the fee that the prover is willing to charge for proving each publication
+        uint96 fee;
+        // the percentage (with two decimals precision) of the fee that is charged for delayed publications.
+        uint16 delayedFeePercentage;
+        // the timestamp of the end of the period. Default to zero while the period is open.
+        uint40 end;
+        // the time by which the prover needs to submit a proof
+        uint40 deadline;
+        // whether the proof came after the deadline
+        bool pastDeadline;
+    }
+}

--- a/src/libs/LibProvingPeriod.sol
+++ b/src/libs/LibProvingPeriod.sol
@@ -1,6 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+/// Each proving period is defined by
+/// - the _prover_ address that must post proofs for any publications received during this period
+/// - the standard proving _fee_ that the prover charges per publication in this period
+/// - the delayed proving fee that the prover charges per delayed publication in this period
+///     - this is defined as a percentage (_delayedFeePercentage_) of the standard proving fee
+/// The prover must lock some _stake_ that can be slashed if they fail to post a proof in a timely manner.
+/// Proving periods are open-ended, meaning that they can be Open for an indefinite amount of time.
+/// The period is Closed when the prover is outbid, chooses to leave, or is evicted for failing to prove.
+/// At this point, the _end_ timestamp is set but the period is still Active. The prover is still required to
+/// prove any publications received until the end timestamp is reached, when the period is Complete.
+/// All publications in the period must be proven by the _deadline_, which should be after the end timestamp.
+/// The prover can then withdraw their remaining stake, and the period is Finalized.
+/// If a prover misses the deadline, anyone can prove outstanding publications on their behalf. In this case, the
+/// _pastDeadline_ flag is set and the address that completes the outstanding proofs receives a fraction of the stake.
 library LibProvingPeriod {
     struct Period {
         // SLOT 1

--- a/src/protocol/BalanceAccounting.sol
+++ b/src/protocol/BalanceAccounting.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+abstract contract BalanceAccounting {
+    mapping(address user => uint256 balance) private _balances;
+
+    /// @notice Get the balance of a user
+    /// @param user The address of the user
+    /// @return The balance of the user
+    function balances(address user) public view returns (uint256) {
+        return _balances[user];
+    }
+
+    function _increaseBalance(address user, uint256 amount) internal {
+        _balances[user] += amount;
+    }
+
+    function _decreaseBalance(address user, uint256 amount) internal {
+        _balances[user] -= amount;
+    }
+}

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -170,17 +170,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
             period.assignReward(msg.sender);
         }
 
-        uint96 baseFee = period.fee;
-        uint256 regularPubFee = (numPublications - numDelayedPublications) * baseFee;
-
-        uint256 delayedPubFee;
-
-        if (numDelayedPublications > 0) {
-            uint96 delayedFee = baseFee.scaleBy(period.delayedFeePercentage, LibPercentage.PERCENT);
-            delayedPubFee = numDelayedPublications * delayedFee;
-        }
-
-        _increaseBalance(period.prover, regularPubFee + delayedPubFee);
+        _increaseBalance(period.prover, period.totalFeeEarned(numPublications, numDelayedPublications));
     }
 
     /// @inheritdoc IProverManager

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -119,7 +119,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         // Reward the evictor and slash the prover
         uint96 evictorIncentive = period.stake.scaleBy(_evictorIncentivePercentage());
         _increaseBalance(msg.sender, evictorIncentive);
-        period.stake -= evictorIncentive;
+        period.slash(evictorIncentive);
 
         emit ProverEvicted(period.prover, msg.sender, end, period.stake);
     }

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -183,11 +183,10 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         require(lastProven.publicationId >= provenPublication.id, "Publication must be proven");
 
         LibProvingPeriod.Period storage period = _periods[periodId];
+        require(period.isInitialized(), "Period not initialized");
         require(period.isBefore(provenPublication.timestamp), "Publication must be after period");
 
-        uint96 stake = period.stake;
-        _increaseBalance(period.prover, period.pastDeadline ? stake.scaleBy(_rewardPercentage()) : stake);
-        period.stake = 0;
+        _increaseBalance(period.prover, period.finalize(_rewardPercentage()));
     }
 
     /// @inheritdoc IProposerFees

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -105,9 +105,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
     /// incentive.
     function evictProver(IPublicationFeed.PublicationHeader calldata publicationHeader) external {
         require(publicationFeed.validateHeader(publicationHeader), "Invalid publication");
-
-        uint256 publicationTimestamp = publicationHeader.timestamp;
-        require(publicationTimestamp + _livenessWindow() < block.timestamp, "Publication is not old enough");
+        require(publicationHeader.timestamp + _livenessWindow() < block.timestamp, "Publication is not old enough");
 
         LibProvingPeriod.Period storage period = _periods[_currentPeriodId];
         require(period.isOpen(), "Proving period is closed");

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -167,11 +167,9 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         checkpointTracker.proveTransition(start, end, numPublications, numDelayedPublications, proof);
 
         if (period.isDeadlinePassed()) {
-            // Whoever proves the final publication in this period can (eventually) call `finalizePastPeriod` to claim a
-            // percentage of the stake. In practice, a single prover will likely close the whole period with one proof.
-            period.prover = msg.sender;
-            period.pastDeadline = true;
+            period.assignReward(msg.sender);
         }
+
         uint96 baseFee = period.fee;
         uint256 regularPubFee = (numPublications - numDelayedPublications) * baseFee;
 

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -284,10 +284,11 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
     function _claimProvingVacancy(uint96 fee, address prover) private {
         uint256 periodId = _currentPeriodId;
         LibProvingPeriod.Period storage period = _periods[periodId];
-        require(period.prover == address(0) && period.isOpen(), "No proving vacancy");
+        LibProvingPeriod.Period storage nextPeriod = _periods[periodId + 1];
+
+        require(period.isVacant(), "No proving vacancy");
         period.close(0, 0);
 
-        LibProvingPeriod.Period storage nextPeriod = _periods[periodId + 1];
         _decreaseBalance(prover, _livenessBond());
         nextPeriod.init(prover, fee, _delayedFeePercentage(), _livenessBond());
     }

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -87,14 +87,10 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         if (currentPeriod.isOpen()) {
             _ensureSufficientUnderbid(currentPeriod.fee, offeredFee);
             currentPeriod.close(_successionDelay(), _provingWindow());
-        } else {
-            address nextProverAddress = nextPeriod.prover;
-            if (nextProverAddress != address(0)) {
-                _ensureSufficientUnderbid(nextPeriod.fee, offeredFee);
-
-                // Refund the liveness bond to the losing bid
-                _increaseBalance(nextProverAddress, nextPeriod.stake);
-            }
+        } else if (nextPeriod.isInitialized()) {
+            _ensureSufficientUnderbid(nextPeriod.fee, offeredFee);
+            // Refund the liveness bond to the losing bid
+            _increaseBalance(nextPeriod.prover, nextPeriod.stake);
         }
 
         // Record the next period info

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -73,9 +73,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         uint256 periodId = _currentPeriodId;
 
         if (_periods[periodId].isComplete()) {
-            // Advance to the next period
-            _currentPeriodId = ++periodId;
-            emit NewPeriod(periodId);
+            periodId = _advancePeriod();
         }
 
         // Deduct fee from proposer's balance
@@ -346,5 +344,12 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         deadline = end + provingWindow_;
         period.end = end;
         period.deadline = deadline;
+    }
+
+    /// @notice mark the next period as active. Future publications will be assigned to the new period
+    function _advancePeriod() private returns (uint256 periodId) {
+        _currentPeriodId++;
+        periodId = _currentPeriodId;
+        emit NewPeriod(periodId);
     }
 }

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -166,8 +166,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
 
         checkpointTracker.proveTransition(start, end, numPublications, numDelayedPublications, proof);
 
-        bool isPastDeadline = block.timestamp > period.deadline && period.deadline != 0;
-        if (isPastDeadline) {
+        if (period.isDeadlinePassed()) {
             // Whoever proves the final publication in this period can (eventually) call `finalizePastPeriod` to claim a
             // percentage of the stake. In practice, a single prover will likely close the whole period with one proof.
             period.prover = msg.sender;

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -13,6 +13,7 @@ import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 abstract contract BaseProverManager is IProposerFees, IProverManager {
     using SafeCast for uint256;
     using LibPercentage for uint96;
+    using LibProvingPeriod for LibProvingPeriod.Period;
 
     address public immutable inbox;
     ICheckpointTracker public immutable checkpointTracker;
@@ -71,8 +72,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
 
         uint256 periodId = _currentPeriodId;
 
-        uint40 periodEnd = _periods[periodId].end;
-        if (periodEnd != 0 && block.timestamp > periodEnd) {
+        if (_periods[periodId].isComplete()) {
             // Advance to the next period
             _currentPeriodId = ++periodId;
             emit NewPeriod(periodId);
@@ -222,8 +222,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
     /// @inheritdoc IProposerFees
     function getCurrentFees() external view returns (uint96 fee, uint96 delayedFee) {
         uint256 currentPeriod = _currentPeriodId;
-        uint40 periodEnd = _periods[currentPeriod].end;
-        if (periodEnd != 0 && block.timestamp > periodEnd) {
+        if (_periods[currentPeriod].isComplete()) {
             // can never overflow
             unchecked {
                 ++currentPeriod;

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -192,16 +192,14 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
     /// @inheritdoc IProposerFees
     function getCurrentFees() external view returns (uint96 fee, uint96 delayedFee) {
         uint256 currentPeriod = _currentPeriodId;
-        if (_periods[currentPeriod].isComplete()) {
-            // can never overflow
-            unchecked {
-                ++currentPeriod;
-            }
+        LibProvingPeriod.Period storage period = _periods[currentPeriod];
+
+        if (period.isComplete()) {
+            period = _periods[currentPeriod + 1];
         }
 
-        LibProvingPeriod.Period storage period = _periods[currentPeriod];
-        fee = period.fee;
-        delayedFee = fee.scaleBy(period.delayedFeePercentage, LibPercentage.PERCENT);
+        fee = period.publicationFee(false);
+        delayedFee = period.publicationFee(true);
     }
 
     /// @notice Get the balance of a user

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -177,12 +177,13 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
     function finalizePastPeriod(uint256 periodId, IPublicationFeed.PublicationHeader calldata provenPublication)
         external
     {
-        ICheckpointTracker.Checkpoint memory lastProven = checkpointTracker.getProvenCheckpoint();
         require(publicationFeed.validateHeader(provenPublication), "Invalid publication header");
+
+        ICheckpointTracker.Checkpoint memory lastProven = checkpointTracker.getProvenCheckpoint();
         require(lastProven.publicationId >= provenPublication.id, "Publication must be proven");
 
         LibProvingPeriod.Period storage period = _periods[periodId];
-        require(provenPublication.timestamp > period.end, "Publication must be after period");
+        require(period.isBefore(provenPublication.timestamp), "Publication must be after period");
 
         uint96 stake = period.stake;
         _increaseBalance(period.prover, period.pastDeadline ? stake.scaleBy(_rewardPercentage()) : stake);

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -5,12 +5,14 @@ import {LibPercentage} from "../libs/LibPercentage.sol";
 import {LibProvingPeriod} from "../libs/LibProvingPeriod.sol";
 
 import {BalanceAccounting} from "./BalanceAccounting.sol";
+
 import {ICheckpointTracker} from "./ICheckpointTracker.sol";
 import {IProposerFees} from "./IProposerFees.sol";
 import {IProverManager} from "./IProverManager.sol";
 import {IPublicationFeed} from "./IPublicationFeed.sol";
+import {ProverManagerConfig} from "./ProverManagerConfig.sol";
 
-abstract contract BaseProverManager is IProposerFees, IProverManager, BalanceAccounting {
+abstract contract BaseProverManager is IProposerFees, IProverManager, BalanceAccounting, ProverManagerConfig {
     using LibPercentage for uint96;
     using LibProvingPeriod for LibProvingPeriod.Period;
 
@@ -222,44 +224,6 @@ abstract contract BaseProverManager is IProposerFees, IProverManager, BalanceAcc
         uint96 requiredMaxFee = fee.scaleBy(_maxBidPercentage());
         require(offeredFee <= requiredMaxFee, "Offered fee not low enough");
     }
-
-    /// @dev Returns the maximum percentage (in bps) of the previous bid a prover can offer and still have a successful
-    /// bid
-    /// @return _ The maximum bid percentage value
-    function _maxBidPercentage() internal view virtual returns (uint16);
-
-    /// @dev Returns the time window after which a publication is considered old enough for prover eviction
-    /// @return _ The liveness window value in seconds
-    function _livenessWindow() internal view virtual returns (uint40);
-
-    /// @dev Returns the time delay before a new prover takes over after a successful bid
-    /// @return _ The succession delay value in seconds
-    function _successionDelay() internal view virtual returns (uint40);
-
-    /// @dev Returns the delay after which the current prover can exit, or is removed if evicted
-    /// @return _ The exit delay value in seconds
-    function _exitDelay() internal view virtual returns (uint40);
-
-    /// @dev Returns the time window for a prover to submit a valid proof after their period ends
-    /// @return _ The proving window value in seconds
-    function _provingWindow() internal view virtual returns (uint40);
-
-    /// @dev Returns the minimum stake required to be a prover
-    /// @return _ The liveness bond value in wei
-    function _livenessBond() internal view virtual returns (uint96);
-
-    /// @dev Returns the percentage (in bps) of the liveness bond that the evictor gets as an incentive
-    /// @return _ The evictor incentive percentage
-    function _evictorIncentivePercentage() internal view virtual returns (uint16);
-
-    /// @dev Returns the percentage (in bps) of the remaining liveness bond rewarded to the prover
-    /// @return _ The reward percentage
-    function _rewardPercentage() internal view virtual returns (uint16);
-
-    /// @dev The percentage of the fee that is charged for delayed publications
-    /// @dev It is recommended to set this to >100 since delayed publications should usually be charged at a higher rate
-    /// @return _ The multiplier as a percentage (two decimals). This value should usually be greater than 100 (100%).
-    function _delayedFeePercentage() internal view virtual returns (uint16);
 
     /// @dev Increases `user`'s balance by `amount` and emits a `Deposit` event
     function _deposit(address user, uint256 amount) internal {

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -10,7 +10,6 @@ import {IPublicationFeed} from "./IPublicationFeed.sol";
 
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
-
 abstract contract BaseProverManager is IProposerFees, IProverManager {
     using SafeCast for uint256;
     using LibPercentage for uint96;

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -158,7 +158,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
 
         require(publicationFeed.validateHeader(lastPub), "Last publication does not exist");
         require(end.publicationId == lastPub.id, "Last publication does not match end checkpoint");
-        require(period.isOpen() || lastPub.timestamp <= period.end, "Last publication is after the period");
+        require(period.isNotBefore(lastPub.timestamp), "Last publication is after the period");
 
         require(publicationFeed.validateHeader(firstPub), "First publication does not exist");
         require(start.publicationId + 1 == firstPub.id, "First publication not immediately after start checkpoint");

--- a/src/protocol/BaseProverManager.sol
+++ b/src/protocol/BaseProverManager.sol
@@ -79,11 +79,7 @@ abstract contract BaseProverManager is IProposerFees, IProverManager {
         }
 
         // Deduct fee from proposer's balance
-        uint96 fee = _periods[periodId].fee;
-        if (isDelayed) {
-            fee = fee.scaleBy(_periods[periodId].delayedFeePercentage, LibPercentage.PERCENT);
-        }
-        _balances[proposer] -= fee;
+        _balances[proposer] -= _periods[periodId].publicationFee(isDelayed);
     }
 
     /// @inheritdoc IProverManager

--- a/src/protocol/ProverManagerConfig.sol
+++ b/src/protocol/ProverManagerConfig.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+abstract contract ProverManagerConfig {
+    /// @dev Returns the maximum percentage (in bps) of the previous bid a prover can offer and still have a successful
+    /// bid
+    /// @return _ The maximum bid percentage value
+    function _maxBidPercentage() internal view virtual returns (uint16);
+
+    /// @dev Returns the time window after which a publication is considered old enough for prover eviction
+    /// @return _ The liveness window value in seconds
+    function _livenessWindow() internal view virtual returns (uint40);
+
+    /// @dev Returns the time delay before a new prover takes over after a successful bid
+    /// @return _ The succession delay value in seconds
+    function _successionDelay() internal view virtual returns (uint40);
+
+    /// @dev Returns the delay after which the current prover can exit, or is removed if evicted
+    /// @return _ The exit delay value in seconds
+    function _exitDelay() internal view virtual returns (uint40);
+
+    /// @dev Returns the time window for a prover to submit a valid proof after their period ends
+    /// @return _ The proving window value in seconds
+    function _provingWindow() internal view virtual returns (uint40);
+
+    /// @dev Returns the minimum stake required to be a prover
+    /// @return _ The liveness bond value in wei
+    function _livenessBond() internal view virtual returns (uint96);
+
+    /// @dev Returns the percentage (in bps) of the liveness bond that the evictor gets as an incentive
+    /// @return _ The evictor incentive percentage
+    function _evictorIncentivePercentage() internal view virtual returns (uint16);
+
+    /// @dev Returns the percentage (in bps) of the remaining liveness bond rewarded to the prover
+    /// @return _ The reward percentage
+    function _rewardPercentage() internal view virtual returns (uint16);
+
+    /// @dev The percentage of the fee that is charged for delayed publications
+    /// @dev It is recommended to set this to >100 since delayed publications should usually be charged at a higher rate
+    /// @return _ The multiplier as a percentage (two decimals). This value should usually be greater than 100 (100%).
+    function _delayedFeePercentage() internal view virtual returns (uint16);
+}

--- a/test/BaseProverManager.t.sol
+++ b/test/BaseProverManager.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import "forge-std/Test.sol";
 
+import {LibProvingPeriod} from "../src/libs/LibProvingPeriod.sol";
 import {BaseProverManager} from "../src/protocol/BaseProverManager.sol";
 import {IProposerFees} from "../src/protocol/IProposerFees.sol";
 import {IProverManager} from "../src/protocol/IProverManager.sol";
@@ -102,7 +103,7 @@ abstract contract BaseProverManagerTest is Test {
         proverManager.bid(maxAllowedFee);
 
         // Check that period 2 has been created
-        BaseProverManager.Period memory period = proverManager.getPeriod(2);
+        LibProvingPeriod.Period memory period = proverManager.getPeriod(2);
 
         assertEq(period.prover, prover1, "Bid not recorded for new period");
         assertEq(period.fee, maxAllowedFee, "Offered fee not set correctly");
@@ -135,7 +136,7 @@ abstract contract BaseProverManagerTest is Test {
         proverManager.bid(secondBidFee);
 
         // Check that period 2 now has prover2 as the prover
-        BaseProverManager.Period memory period = proverManager.getPeriod(2);
+        LibProvingPeriod.Period memory period = proverManager.getPeriod(2);
         assertEq(period.prover, prover2, "Prover2 should now be the next prover");
         assertEq(period.fee, secondBidFee, "Fee should be updated to prover2's bid");
 
@@ -159,7 +160,7 @@ abstract contract BaseProverManagerTest is Test {
         vm.prank(prover1);
         proverManager.bid(bidFee);
 
-        BaseProverManager.Period memory period = proverManager.getPeriod(1);
+        LibProvingPeriod.Period memory period = proverManager.getPeriod(1);
         assertEq(
             period.end,
             timestampBefore + SUCCESSION_DELAY,
@@ -216,7 +217,7 @@ abstract contract BaseProverManagerTest is Test {
         IPublicationFeed.PublicationHeader memory header = _insertPublication();
 
         // Capture current period stake before eviction
-        BaseProverManager.Period memory periodBefore = proverManager.getPeriod(1);
+        LibProvingPeriod.Period memory periodBefore = proverManager.getPeriod(1);
         uint256 stakeBefore = periodBefore.stake;
         uint256 incentive = _calculatePercentageBPS(stakeBefore, EVICTOR_INCENTIVE_PERCENTAGE);
 
@@ -230,7 +231,7 @@ abstract contract BaseProverManagerTest is Test {
         proverManager.evictProver(header);
 
         // Verify period 1 is marked as evicted and its stake reduced
-        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(1);
+        LibProvingPeriod.Period memory periodAfter = proverManager.getPeriod(1);
         assertEq(periodAfter.deadline, vm.getBlockTimestamp() + EXIT_DELAY, "Prover should be evicted");
         assertEq(periodAfter.end, vm.getBlockTimestamp() + EXIT_DELAY, "Period end not set correctly");
         assertEq(periodAfter.stake, stakeBefore - incentive, "Stake not reduced correctly");
@@ -307,7 +308,7 @@ abstract contract BaseProverManagerTest is Test {
         proverManager.exit();
 
         // Check that period 1 now has an end time and deadline set
-        BaseProverManager.Period memory period = proverManager.getPeriod(1);
+        LibProvingPeriod.Period memory period = proverManager.getPeriod(1);
         assertEq(period.end, vm.getBlockTimestamp() + EXIT_DELAY, "Exit did not set period end correctly");
         assertEq(
             period.deadline, vm.getBlockTimestamp() + EXIT_DELAY + PROVING_WINDOW, "Proving deadline not set correctly"
@@ -354,12 +355,12 @@ abstract contract BaseProverManagerTest is Test {
         proverManager.claimProvingVacancy(newFee);
 
         // Check that period 2(the vacant period) has been closed correctly
-        BaseProverManager.Period memory period2 = proverManager.getPeriod(2);
+        LibProvingPeriod.Period memory period2 = proverManager.getPeriod(2);
         assertEq(period2.end, vm.getBlockTimestamp(), "Period 2 end timestamp should be the current timestamp");
         assertEq(period2.deadline, vm.getBlockTimestamp(), "Period 2 deadline should be the current timestamp");
 
         // Check that period 3 has been created correctly
-        BaseProverManager.Period memory period3 = proverManager.getPeriod(3);
+        LibProvingPeriod.Period memory period3 = proverManager.getPeriod(3);
         assertEq(period3.prover, prover1, "Prover1 should be the new prover");
         assertEq(period3.fee, newFee, "Fee should be set to the new fee");
         assertEq(period3.stake, LIVENESS_BOND, "Liveness bond should be locked");
@@ -546,7 +547,7 @@ abstract contract BaseProverManagerTest is Test {
         );
 
         // Verify period 1 has been updated
-        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(1);
+        LibProvingPeriod.Period memory periodAfter = proverManager.getPeriod(1);
         assertEq(periodAfter.prover, prover1, "Prover should be updated to the new prover");
         assertTrue(periodAfter.pastDeadline, "Period should be marked as past deadline");
 
@@ -609,7 +610,7 @@ abstract contract BaseProverManagerTest is Test {
         assertEq(prover2BalanceAfter, INITIAL_FEE * 2, "Prover2 should receive the fees");
 
         // Verify the period is marked as past deadline
-        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(1);
+        LibProvingPeriod.Period memory periodAfter = proverManager.getPeriod(1);
         assertTrue(periodAfter.pastDeadline, "Period should be marked as past deadline");
     }
 
@@ -776,7 +777,7 @@ abstract contract BaseProverManagerTest is Test {
         proverManager.finalizePastPeriod(INITIAL_PERIOD, afterPeriodHeader);
 
         // Verify a portion of the stake was transferred to the prover
-        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(INITIAL_PERIOD);
+        LibProvingPeriod.Period memory periodAfter = proverManager.getPeriod(INITIAL_PERIOD);
         assertEq(periodAfter.stake, 0, "Stake should be zero after finalization");
 
         uint256 initialProverBalanceAfter = proverManager.balances(initialProver);
@@ -843,7 +844,7 @@ abstract contract BaseProverManagerTest is Test {
         proverManager.finalizePastPeriod(INITIAL_PERIOD, afterPeriodHeader);
 
         // Verify a portion of the stake was transferred to prover1
-        BaseProverManager.Period memory periodAfter = proverManager.getPeriod(INITIAL_PERIOD);
+        LibProvingPeriod.Period memory periodAfter = proverManager.getPeriod(INITIAL_PERIOD);
         assertEq(periodAfter.stake, 0, "Stake should be zero after finalization");
 
         uint256 initialProverBalanceAfter = proverManager.balances(initialProver);

--- a/test/BaseProverManager.t.sol
+++ b/test/BaseProverManager.t.sol
@@ -274,7 +274,7 @@ abstract contract BaseProverManagerTest is Test {
         // Evict the prover
         vm.warp(vm.getBlockTimestamp() + LIVENESS_WINDOW + 1);
         vm.prank(evictor);
-        vm.expectRevert("Proving period is not active");
+        vm.expectRevert("Proving period is closed");
         proverManager.evictProver(header);
     }
 
@@ -328,7 +328,7 @@ abstract contract BaseProverManagerTest is Test {
 
         // Try to exit again
         vm.prank(initialProver);
-        vm.expectRevert("Prover already exited");
+        vm.expectRevert("Period already closed");
         proverManager.exit();
     }
 

--- a/test/BaseProverManager.t.sol
+++ b/test/BaseProverManager.t.sol
@@ -986,7 +986,6 @@ abstract contract BaseProverManagerTest is Test {
         return amount * percentage / 100;
     }
 
-
     function _exit(address prover) internal {
         vm.prank(prover);
         proverManager.exit();


### PR DESCRIPTION
The PR is almost a pure refactor. The only functional changes are:
- a bug fix in `finalizePastPeriod` to ensure the target period is closed.
- `finalizePastPeriod` now zeroes out the prover and requires the period to have a non-zero prover. This means it can only be called once per period.

The main changes are moving period-related functionality to a new library for better readability and encapsulation. It also moves the balance accounting and configuration parameters into their own abstract contracts for better encapsulation.
