### PR TITLE
PoC to improve accessibility of same-slot messaging

### DIFF
--- a/src/protocol/fabric/ISignaler.sol
+++ b/src/protocol/fabric/ISignaler.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface ISignaler {
+    /// @notice Represents a single call within a batch.
+    struct Call {
+        address to;
+        uint256 value;
+        bytes data;
+    }
+
+    function executeBatch(Call[] calldata calls) external;
+    function executeBatchWithSig(Call[] calldata calls, bytes calldata signature) external;
+    function setSignalService(address signalService_) external;
+    function signalService() external view returns (address);
+    function nonce() external view returns (uint256);
+
+    /// @notice Emitted for every individual call executed.
+    event CallExecuted(address indexed sender, address indexed to, uint256 value, bytes data);
+    /// @notice Emitted when a full batch is executed.
+    event BatchExecuted(uint256 indexed nonce, Call[] calls);
+
+    // errors
+    error NotOwner();
+    error InvalidSignature();
+    error InvalidNonce();
+    error CallReverted();
+}

--- a/src/protocol/fabric/Signaler.sol
+++ b/src/protocol/fabric/Signaler.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ISignalService} from "../../signal/ISignalService.sol";
+import {ISignaler} from "./ISignaler.sol";
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+contract Signaler is ISignaler {
+    address private _signalService;
+    uint256 private _nonce;
+
+    /**
+     * @notice Executes a batch of calls initiated by the account owner.
+     * @param calls An array of Call structs containing destination, ETH value, and calldata.
+     */
+    function executeBatch(Call[] calldata calls) external {
+        if (msg.sender != address(this)) revert NotOwner();
+        _executeBatch(calls);
+    }
+
+    /**
+     * @notice Executes a batch of calls using an off–chain signature.
+     * @param calls An array of Call structs containing destination, ETH value, and calldata.
+     * @param signature The ECDSA signature over the current nonce and the call data.
+     *
+     * The signature must be produced off–chain by signing:
+     * The signing key should be the account's key (which becomes the smart account's own identity after upgrade).
+     */
+    function executeBatchWithSig(Call[] calldata calls, bytes calldata signature) external {
+        // Compute the digest that the account was expected to sign.
+        bytes memory encodedCalls;
+        for (uint256 i = 0; i < calls.length; i++) {
+            encodedCalls = abi.encodePacked(encodedCalls, calls[i].to, calls[i].value, calls[i].data);
+        }
+        bytes32 digest = keccak256(abi.encodePacked(_nonce, encodedCalls));
+
+        bytes32 ethSignedMessageHash = MessageHashUtils.toEthSignedMessageHash(digest);
+
+        // Recover the signer from the provided signature.
+        address recovered = ECDSA.recover(ethSignedMessageHash, signature);
+        if (recovered != address(this)) revert InvalidSignature();
+
+        _executeBatch(calls);
+    }
+
+    function setSignalService(address signalService_) external {
+        if (msg.sender != address(this)) revert NotOwner();
+        _signalService = signalService_;
+    }
+
+    // Allow the contract to receive ETH
+    fallback() external payable {}
+    receive() external payable {}
+
+    // internal functions
+    function _executeBatch(Call[] calldata calls) internal {
+        uint256 currentNonce = _nonce;
+        _nonce++; // Increment nonce to protect against replay attacks
+
+        for (uint256 i = 0; i < calls.length; i++) {
+            _executeCall(calls[i]);
+        }
+
+        emit BatchExecuted(currentNonce, calls);
+    }
+
+    function _executeCall(Call calldata call) internal {
+        (bool success, bytes memory returnData) = call.to.call{value: call.value}(call.data);
+        if (!success) revert CallReverted();
+
+        // Hash the inputs and outputs of the call
+        bytes32 signal = _hashSignal(call, returnData);
+
+        // Send the signal to the signal service contract
+        _sendSignal(signal);
+
+        emit CallExecuted(msg.sender, call.to, call.value, call.data);
+    }
+
+    function _sendSignal(bytes32 signal) internal returns (bytes32 slot) {
+        return ISignalService(_signalService).sendSignal(signal);
+    }
+
+    function _hashSignal(Call calldata callData, bytes memory output) internal pure returns (bytes32) {
+        bytes32 signal = keccak256(abi.encode(callData, output));
+        return signal;
+    }
+
+    // view functions
+    function signalService() external view returns (address) {
+        return _signalService;
+    }
+
+    function nonce() external view returns (uint256) {
+        return _nonce;
+    }
+}

--- a/test/fabric/Signaler.t.sol
+++ b/test/fabric/Signaler.t.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+
+import {ISignaler} from "../../src/protocol/fabric/ISignaler.sol";
+import {Signaler} from "../../src/protocol/fabric/Signaler.sol";
+
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+contract DumbOracle {
+    uint256 private _price;
+
+    function setPrice(uint256 price_) external returns (uint256) {
+        _price = price_;
+        return _price;
+    }
+
+    function getPrice() external view returns (uint256) {
+        return _price;
+    }
+}
+
+contract MockSignalService {
+    bytes32 private _signal;
+
+    function sendSignal(bytes32 signal_) external returns (bytes32 slot) {
+        _signal = signal_;
+        return bytes32("0x1337");
+    }
+
+    function getSignal() external view returns (bytes32) {
+        return _signal;
+    }
+}
+
+/**
+ * @title SignalerTest
+ * @dev Test contract for Signaler functionality
+ */
+contract SignalerTest is Test {
+    address public signalService;
+    address alice;
+    uint256 alicePrivateKey;
+    uint256 aliceInitialBalance;
+    address bob;
+
+    function setUp() public {
+        (alice, alicePrivateKey) = makeAddrAndKey("alice");
+        bob = makeAddr("bob");
+        aliceInitialBalance = 100 ether;
+        vm.deal(alice, aliceInitialBalance);
+
+        // Create a mock SignalService instance
+        signalService = address(new MockSignalService());
+        console.log("signalService address", signalService);
+
+        // Create the Signaler instance
+        Signaler _signaler = new Signaler();
+        console.log("signaler address", address(_signaler));
+
+        // Alice uses the Signaler as her 7702 account
+        vm.signAndAttachDelegation(address(_signaler), alicePrivateKey);
+
+        // Alice sets the SignalService address
+        vm.prank(alice);
+        ISignaler(address(alice)).setSignalService(signalService);
+    }
+
+    /**
+     * @dev Helper function to encode multiple calls into a single bytes array
+     * @param calls Array of calls to encode
+     * @return Encoded bytes representation of the calls
+     */
+    function encodeCalls(ISignaler.Call[] memory calls) internal returns (bytes memory) {
+        bytes memory encodedCalls = "";
+        for (uint256 i = 0; i < calls.length; i++) {
+            encodedCalls = abi.encodePacked(encodedCalls, calls[i].to, calls[i].value, calls[i].data);
+        }
+        return encodedCalls;
+    }
+
+    /**
+     * @dev Helper function to sign a batch of calls
+     * @param privateKey The private key of the signer
+     * @param calls The calls to sign
+     * @param nonce The nonce of the signer
+     * @return signature The signed batch of calls
+     */
+    function signBatch(uint256 privateKey, ISignaler.Call[] memory calls, uint256 nonce)
+        internal
+        returns (bytes memory signature)
+    {
+        bytes memory encodedCalls = encodeCalls(calls);
+        bytes32 digest = keccak256(abi.encodePacked(nonce, encodedCalls));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, MessageHashUtils.toEthSignedMessageHash(digest));
+        signature = abi.encodePacked(r, s, v);
+    }
+
+    /**
+     * @dev Test basic contract deployment with 7702
+     */
+    function test_deploy() public {
+        require(address(alice).code.length != 0);
+        require(ISignaler(address(alice)).nonce() == 0, "interface works");
+        require(ISignaler(address(alice)).signalService() == signalService, "signalService is set");
+    }
+
+    /**
+     * @dev Test basic ETH transfer functionality works despite 7702
+     */
+    function test_basicTransfer() public {
+        vm.prank(alice);
+        (bool success,) = bob.call{value: 1 ether}("");
+        require(success, "transfer failed");
+        assertEq(bob.balance, 1 ether);
+        assertEq(alice.balance, aliceInitialBalance - 1 ether);
+    }
+
+    /**
+     * @dev Test batch ETH transfers initiated by the owner
+     */
+    function test_executeBatch() public {
+        // Alice pre-signs an ETH transfer to Bob
+        address dest1 = makeAddr("dest1");
+        address dest2 = makeAddr("dest2");
+        ISignaler.Call[] memory calls = new ISignaler.Call[](2);
+        calls[0] = ISignaler.Call({to: dest1, value: 1 ether, data: ""});
+        calls[1] = ISignaler.Call({to: dest2, value: 1 ether, data: ""});
+
+        // Alice submits the call
+        vm.prank(alice);
+        ISignaler(address(alice)).executeBatch(calls);
+
+        // Verify the transfer was executed
+        assertEq(dest1.balance, 1 ether);
+        assertEq(dest2.balance, 1 ether);
+    }
+
+    /**
+     * @dev Test batch ETH transfer functionality using executeBatchWithSig, submitted by a non-owner
+     */
+    function test_executeBatchWithSig() public {
+        address dest1 = makeAddr("dest1");
+        address dest2 = makeAddr("dest2");
+
+        // Create two transfer calls
+        ISignaler.Call[] memory calls = new ISignaler.Call[](2);
+        calls[0] = ISignaler.Call({to: dest1, value: 1 ether, data: ""});
+        calls[1] = ISignaler.Call({to: dest2, value: 1 ether, data: ""});
+
+        // Encode and sign the batch
+        bytes memory signature = signBatch(alicePrivateKey, calls, ISignaler(address(alice)).nonce());
+
+        // Execute the batch
+        vm.prank(bob); // not alice
+        ISignaler(address(alice)).executeBatchWithSig(calls, signature);
+
+        // Verify balances
+        assertEq(dest1.balance, 1 ether);
+        assertEq(dest2.balance, 1 ether);
+    }
+
+    function test_sendSignal() public {
+        // Create a new DumbOracle instance
+        DumbOracle oracle = new DumbOracle();
+        uint256 price = 42;
+
+        // Create the call
+        ISignaler.Call[] memory calls = new ISignaler.Call[](1);
+        calls[0] = ISignaler.Call({
+            to: address(oracle),
+            value: 0,
+            data: abi.encodeWithSelector(DumbOracle.setPrice.selector, price)
+        });
+
+        // Encode and sign the batch
+        bytes memory signature = signBatch(alicePrivateKey, calls, ISignaler(address(alice)).nonce());
+
+        // Delegate batch execution using a signature
+        vm.prank(bob); // not owner
+        ISignaler(address(alice)).executeBatchWithSig(calls, signature);
+
+        // Verify the price was set
+        assertEq(oracle.getPrice(), price, "price was not set");
+
+        // Verify the right signal was sent
+        bytes32 gotSignal = MockSignalService(signalService).getSignal();
+        bytes32 expectedSignal = keccak256(abi.encode(calls[0], abi.encode(price)));
+        assertEq(gotSignal, expectedSignal, "signal was not sent");
+    }
+}


### PR DESCRIPTION
`Signaler.sol` contains logic that is meant to be attached to EOAs via EIP-7702. The idea is to add a post-execution hook to EOAs that writes relevant data to the L1 `SignalService` contract. 

The motivation is that while the `SignalService` contract enables same-slot L1->L2 messaging, the messages are limited to what is written to the L1 `SignalService` contract. Ideally the L2 can synchronously read *all* L1 data. Unfortunately, this seems to require either ToB execution to read arbitrary data from the latest L1 slot (as described by Gwyneth’s Ultra TXs) or EIP-7814 which allows the L1 state to be introspected and passed to the L2, during the L1’s execution.

This PoC is a hacky shortcut to get closer to the end goal, by making it more seamless to populate the `SignalService` contract with signals. 

To illustrate this, we can look to an oracle example: Assume ChainLink just posted the latest pricefeed to the L1.
- **ideal case**: The *current* inter-block L1 state is sent as a signal to the L2 via EIP-7814, and the pricefeed contract's storage slot can be proven to the L2
- **ToB case with Mega Txs**: not possible, can only read the post-stateroot from the previous L1 block 
- **ToB case with Ultra Txs**: the pricefeed transaction is emulated in L2 -> ultra tx magic -> price is available 
- **Same slot msging with `Signaler.sol`**: Oracle delegates EOA logic to `Signaler` contract via EIP-7702. Upon posting the price, the related IO is automatically sent as a signal to the `SignalService` contract making the price available to L2 contracts. 
- **Less portable approach without 7702**: Oracle posts to a dedicated proxy contract which posts the pricefeed, then posts the signal
- **Even less practical**: Chainlink upgrades their pricefeed contract to post directly to the SignalService contract 😅

In summary, if wallets adopt `Signaler.sol` it will vastly increase the breadth of data that can be passed from L1->L2 in the same slot, potentially allowing more synchronous composability use-cases before we have nice things like EIP-7814.