### PR TITLE
bytes32 --> uint256

### DIFF
--- a/src/protocol/taiko_alethia/TaikoAnchor.sol
+++ b/src/protocol/taiko_alethia/TaikoAnchor.sol
@@ -21,7 +21,7 @@ struct BlockHeader {
     bytes extraData;
     bytes32 mixedHash;
     uint64 nonce;
-    bytes32 baseFeePerGas;
+    uint256 baseFeePerGas;
     bytes32 withdrawalsRoot;
     uint64 blobGasUsed;
     uint64 excessBlobGas;


### PR DESCRIPTION
BaseFeePerGas / BaseFee should be a bigint (uint256) not a bytes 32

https://github.com/ethereum/go-ethereum/blob/9e0611b660dae905c87fcf49edc99cd41815bd87/core/types/block.go#L93