### PR TITLE
Make EthBridge unaware of relayer selection logic and allow arbitrary context instead

### DIFF
--- a/offchain/deposit_signal_proof.rs
+++ b/offchain/deposit_signal_proof.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
     println!("Deployed ETH bridge at address: {}", eth_bridge.address());
 
     println!("Sending ETH deposit...");
-    let builder = eth_bridge.deposit(sender, data).value(amount);
+    let builder = eth_bridge.deposit(sender, data, bytes!()).value(amount);
     let tx = builder.send().await?.get_receipt().await?;
 
     // Get deposit ID from the transaction receipt logs

--- a/src/protocol/ETHBridge.sol
+++ b/src/protocol/ETHBridge.sol
@@ -49,8 +49,8 @@ contract ETHBridge is IETHBridge, ReentrancyGuardTransient {
     }
 
     /// @inheritdoc IETHBridge
-    function deposit(address to, bytes memory data, address relayer) public payable returns (bytes32 id) {
-        ETHDeposit memory ethDeposit = ETHDeposit(_globalDepositNonce, msg.sender, to, msg.value, data, relayer);
+    function deposit(address to, bytes memory data, bytes memory context) public payable returns (bytes32 id) {
+        ETHDeposit memory ethDeposit = ETHDeposit(_globalDepositNonce, msg.sender, to, msg.value, data, context);
         id = _generateId(ethDeposit);
         unchecked {
             ++_globalDepositNonce;

--- a/src/protocol/IETHBridge.sol
+++ b/src/protocol/IETHBridge.sol
@@ -17,9 +17,8 @@ interface IETHBridge {
         uint256 amount;
         // Any calldata to be sent to the receiver in case of a contract
         bytes data;
-        // Allows depositer to specify a relayer address if they want
-        // in order to avoid race conditions (zero address to allow any relayer)
-        address relayer;
+        // Application-specific context data (e.g., for relayer selection, tips, etc.)
+        bytes context;
     }
 
     /// @dev Emitted when a deposit is made.
@@ -49,8 +48,8 @@ interface IETHBridge {
     /// @dev Creates an ETH deposit with `msg.value`
     /// @param to The receiver of the deposit
     /// @param data Any calldata to be sent to the receiver in case of a contract
-    /// @param relayer Address of the allowed relayer (0 for any)
-    function deposit(address to, bytes memory data, address relayer) external payable returns (bytes32 id);
+    /// @param context Application-specific context data
+    function deposit(address to, bytes memory data, bytes memory context) external payable returns (bytes32 id);
 
     /// @dev Claims an ETH deposit created by the sender (`from`) with `nonce`. The `value` ETH claimed  is
     /// sent to the receiver (`to`) after verifying a storage proof.

--- a/test/signal/ETHBridge.t.sol
+++ b/test/signal/ETHBridge.t.sol
@@ -44,8 +44,8 @@ contract BridgeETHState is BaseState {
         vm.prank(defaultSender);
         vm.deal(defaultSender, senderBalanceL1);
         bytes memory emptyData = "";
-        address relayer = address(0);
-        depositIdOne = L1EthBridge.deposit{value: depositAmount}(defaultSender, emptyData, relayer);
+        bytes memory context = "";
+        depositIdOne = L1EthBridge.deposit{value: depositAmount}(defaultSender, emptyData, context);
     }
 }
 
@@ -117,10 +117,10 @@ contract ClaimDepositTest is CommitmentStoredState {
         ISignalService.SignalProof memory signalProof =
             ISignalService.SignalProof(accountProof, storageProof, stateRoot, blockHash);
         bytes memory encodedProof = abi.encode(signalProof);
-        address relayer = address(0);
+        bytes memory context = "";
 
         IETHBridge.ETHDeposit memory depositOne =
-            IETHBridge.ETHDeposit(0, defaultSender, defaultSender, depositAmount, bytes(""), relayer);
+            IETHBridge.ETHDeposit(0, defaultSender, defaultSender, depositAmount, bytes(""), context);
 
         vm.selectFork(L2Fork);
         L2EthBridge.claimDeposit(depositOne, commitmentHeight, encodedProof);


### PR DESCRIPTION
Fixes #128 

We could also send the `tip` and `gasLimit` in the new context field, but that would require us decoding the struct in `receiveMessage` as well, with no benefit(outside some marginal clarity). Because of that I decided to keep that as part of the expected `data` to serve as parameters of the call that the bridge does