### PR TITLE
Parent gas used from bytes32 --> uint32

### DIFF
--- a/src/protocol/taiko_alethia/TaikoAnchor.sol
+++ b/src/protocol/taiko_alethia/TaikoAnchor.sol
@@ -30,7 +30,7 @@ struct BlockHeader {
 }
 
 contract TaikoAnchor {
-    event Anchor(uint256 publicationId, uint256 anchorBlockId, bytes32 anchorBlockHash, bytes32 parentGasUsed);
+    event Anchor(uint256 publicationId, uint256 anchorBlockId, bytes32 anchorBlockHash, uint32 parentGasUsed);
 
     /// @dev The header provided does not match the block hash
     /// @param headerHash The header hash
@@ -84,7 +84,7 @@ contract TaikoAnchor {
         uint256 _anchorBlockId,
         bytes32 _anchorBlockHash,
         BlockHeader calldata _anchorBlockHeader,
-        bytes32 _parentGasUsed
+        uint32 _parentGasUsed
     ) external onlyFromPermittedSender {
         // Make sure this function can only succeed once per publication
         require(_publicationId > lastPublicationId, "publicationId too small");
@@ -151,7 +151,7 @@ contract TaikoAnchor {
     }
 
     // For now, we simply use a constant base fee
-    function _verifyBaseFee(bytes32 /*_parentGasUsed*/ ) internal view {
+    function _verifyBaseFee(uint32 /*_parentGasUsed*/ ) internal view {
         require(block.basefee == fixedBaseFee, "basefee mismatch");
     }
 }


### PR DESCRIPTION
change parent gas used from bytes 32 to uint 32 in checkpoint tracker

I believe this is a mistake given:
https://github.com/taikoxyz/taiko-mono/blob/c6235659b3e7f587f3138d81fac87822bf5eaa71/packages/protocol/contracts/layer2/based/anchor/ShastaAnchor.sol#L52 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the data type for the parent gas used parameter and event field to a more precise format, improving clarity in related contract events and functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->