### PR TITLE
Fix Message Relayer

### DIFF
--- a/src/protocol/IMessageRelayer.sol
+++ b/src/protocol/IMessageRelayer.sol
@@ -27,7 +27,8 @@ interface IMessageRelayer {
     /// @param ethDeposit The deposit to claim
     /// @param height The `height` of the checkpoint on the source chain (i.e. the block number or publicationId)
     /// @param proof Proof of the deposit
-    /// @param tipRecipient Address the relayer will send the tip to (chosen by the relayer)
+    /// @param tipRecipient Address the relayer will send the tip to (chosen by the relayer) if not specified as part of
+    /// the ethDeposit
     function relayMessage(
         IETHBridge.ETHDeposit memory ethDeposit,
         uint256 height,

--- a/src/protocol/taiko_alethia/MessageRelayer.sol
+++ b/src/protocol/taiko_alethia/MessageRelayer.sol
@@ -6,7 +6,6 @@ import {TransientSlot} from "@openzeppelin/contracts/utils/TransientSlot.sol";
 import {IETHBridge} from "src/protocol/IETHBridge.sol";
 
 import {IMessageRelayer} from "src/protocol/IMessageRelayer.sol";
-import {MessageRelayer} from "src/protocol/taiko_alethia/MessageRelayer.sol";
 
 /// @dev Simple implementation of a message relayer.
 ///
@@ -29,28 +28,26 @@ import {MessageRelayer} from "src/protocol/taiko_alethia/MessageRelayer.sol";
 ///            IMessageRelayer.receiveMessage,
 ///            (
 ///                address(Alice),    // to
-///                address(tipRecipient) // specified tip recipient
 ///                0.1 ether,        // tip for the relayer
+///                address(tipRecipient) // specified tip recipient
 ///                0,                // gas limit
 ///                ""                // data (in this case empty)
 ///            )
 ///        )
 ///
 /// To relay the message:
-/// 1. Anyone is allowed to call `relayMessage` however the tip recipient is determined by one of the two following
-/// cases:
-///     a) If no tip recipient is specified in the ETHDeposit message the one in temporary storage will be used
-///     b) If a tip recipient is specified in the ETHDeposit message it will be used
-/// It is up to the relayer to decide whether it is worth to relay this message or not (decided if they control the
-/// tipRecipient address or not)
-///    2. This will call claimDeposit on the ETHBridge
-///    3. If the original message was specified correctly, this will call receiveMessage on this contract
-///    4. This will call the message recipient and send the tip to the tip recipient
+///    1. Trigger the relay:
+///      a) If the tip recipient is specified in the ETHDeposit, the relayer can call `ETHBridge.claimDeposit` directly.
+///      b) Otherwise, anyone can pass a tip recipient to `relayMessage`, which will then call `ETHBridge.claimDeposit`.
+///         Note that the provided recipient will be ignored if it already specified.
+///      Relayers should ensure the tip they receive is sufficient compensation for the gas spent on this call.
+///    2. If the original message was specified correctly, `claimDeposit` will invoke `receiveMessage` on this contract.
+///    3. This will call the message recipient and send the tip to the tip recipient.
 ///
-/// The tip recipient will net any tip minus the gas spent on the call to relayMessage.
-///
-/// WARN: There is no relayer protection. In particular:
-///    - if the ETHDeposit does not invoke receiveMessage, the tip recipient will not be paid.
+/// WARN: There is no relayer protection. In particular
+/// - if the ETHDeposit does not invoke `receiveMessage`, the tip recipient will not be paid.
+/// - if a relayer calls `claimDeposit` directly (case 1a above) but no recipient is specified, the tip will be sent
+///   to whichever address happens to be stored in the `TIP_RECIPIENT_SLOT` (including address(0)).
 contract MessageRelayer is ReentrancyGuardTransient, IMessageRelayer {
     using TransientSlot for *;
 
@@ -66,8 +63,7 @@ contract MessageRelayer is ReentrancyGuardTransient, IMessageRelayer {
     uint256 private constant BUFFER = 20_000;
 
     /// @inheritdoc IMessageRelayer
-    /// @dev Only specify a tip recipient if one is not set in the ETHDeposit data field otherwise
-    /// that one will be used instead
+    /// @dev `ETHBridge.claimDeposit` should be called instead if the tip recipient is specified in the `ethDeposit`.
     function relayMessage(
         IETHBridge.ETHDeposit memory ethDeposit,
         uint256 height,
@@ -90,7 +86,7 @@ contract MessageRelayer is ReentrancyGuardTransient, IMessageRelayer {
         address tipRecipient = userSelectedTipRecipient;
 
         // If none specified use the one in temporary storage
-        if (tipRecipient == address(0)) {
+        if (userSelectedTipRecipient == address(0)) {
             tipRecipient = TIP_RECIPIENT_SLOT.asAddress().tload();
         }
 


### PR DESCRIPTION
This fixes an issue described in https://github.com/OpenZeppelin/minimal-rollup/issues/138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now specify a tip recipient address when relaying messages, allowing for more flexible tip distribution.

* **Refactor**
  * The tip recipient is now explicitly provided or retrieved from temporary storage, replacing previous implicit handling.
  * Relayer authorization checks based on the context field have been removed, enabling open message relaying.
  * Documentation and comments updated to clarify tip recipient handling and relayer permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->