### PR TITLE
ERC20, ERC721 and ERC1155 Bridge contracts and tests

### DIFF
--- a/src/protocol/BridgedERC1155.sol
+++ b/src/protocol/BridgedERC1155.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BridgedTokenBase} from "./BridgedTokenBase.sol";
+import {IMintableERC1155} from "./IMintable.sol";
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+/// @title BridgedERC1155
+/// @notice An ERC1155 token that represents a bridged token from another chain
+/// @dev Only the bridge contract can mint and burn tokens
+contract BridgedERC1155 is ERC1155, BridgedTokenBase, IMintableERC1155 {
+    /// @dev Mapping from token ID to custom token URI
+    mapping(uint256 => string) private _tokenURIs;
+
+    constructor(string memory uri_, address _originalToken) ERC1155(uri_) BridgedTokenBase(_originalToken) {}
+
+    /// @inheritdoc IMintableERC1155
+    function mint(address to, uint256 id, uint256 amount, bytes memory data) external onlyOwner {
+        _mint(to, id, amount, data);
+    }
+
+    /// @dev Mints tokens with custom URI
+    /// @param to Address to mint the tokens to
+    /// @param id Token ID to mint
+    /// @param amount Amount to mint
+    /// @param tokenURI_ Custom URI for this token
+    /// @param data Additional data
+    function mintWithURI(address to, uint256 id, uint256 amount, string memory tokenURI_, bytes memory data)
+        external
+        onlyOwner
+    {
+        _mint(to, id, amount, data);
+        _setTokenURI(id, tokenURI_);
+    }
+
+    /// @inheritdoc IMintableERC1155
+    function burn(uint256 id, uint256 amount) external onlyOwner {
+        _burn(msg.sender, id, amount);
+    }
+
+    /// @dev See {IERC1155MetadataURI-uri}.
+    function uri(uint256 tokenId) public view virtual override returns (string memory) {
+        string memory _tokenURI = _tokenURIs[tokenId];
+
+        // If there is a custom URI for this token, return it
+        if (bytes(_tokenURI).length > 0) {
+            return _tokenURI;
+        }
+
+        // Otherwise, fall back to the default behavior
+        return super.uri(tokenId);
+    }
+
+    /// @dev Sets the token URI for a specific token
+    /// @param tokenId Token ID to set URI for
+    /// @param tokenURI_ URI to set
+    function _setTokenURI(uint256 tokenId, string memory tokenURI_) internal {
+        _tokenURIs[tokenId] = tokenURI_;
+    }
+}

--- a/src/protocol/BridgedERC20.sol
+++ b/src/protocol/BridgedERC20.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BridgedTokenBase} from "./BridgedTokenBase.sol";
+import {IMintableERC20} from "./IMintable.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title BridgedERC20
+/// @notice An ERC20 token that represents a bridged token from another chain
+/// @dev Only the bridge contract can mint and burn tokens
+contract BridgedERC20 is ERC20, BridgedTokenBase, IMintableERC20 {
+    uint8 private immutable _decimals;
+
+    constructor(string memory name, string memory symbol, uint8 decimals_, address _originalToken)
+        ERC20(name, symbol)
+        BridgedTokenBase(_originalToken)
+    {
+        _decimals = decimals_;
+    }
+
+    /// @inheritdoc IMintableERC20
+    function mint(address to, uint256 amount) external onlyOwner {
+        _mint(to, amount);
+    }
+
+    /// @inheritdoc IMintableERC20
+    function burn(uint256 amount) external onlyOwner {
+        _burn(msg.sender, amount);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
+    }
+}

--- a/src/protocol/BridgedERC721.sol
+++ b/src/protocol/BridgedERC721.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BridgedTokenBase} from "./BridgedTokenBase.sol";
+import {IMintableERC721} from "./IMintable.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+/// @title BridgedERC721
+/// @notice An ERC721 token that represents a bridged token from another chain
+/// @dev Only the bridge contract can mint and burn tokens
+contract BridgedERC721 is ERC721, BridgedTokenBase, IMintableERC721 {
+    /// @dev Mapping from token ID to custom token URI
+    mapping(uint256 => string) private _tokenURIs;
+
+    constructor(string memory name, string memory symbol, address _originalToken)
+        ERC721(name, symbol)
+        BridgedTokenBase(_originalToken)
+    {}
+
+    /// @inheritdoc IMintableERC721
+    function mint(address to, uint256 tokenId) external onlyOwner {
+        _mint(to, tokenId);
+    }
+
+    /// @dev Mints a token with custom URI
+    /// @param to Address to mint the token to
+    /// @param tokenId Token ID to mint
+    /// @param tokenURI_ Custom URI for this token
+    function mintWithURI(address to, uint256 tokenId, string memory tokenURI_) external onlyOwner {
+        _mint(to, tokenId);
+        _setTokenURI(tokenId, tokenURI_);
+    }
+
+    /// @inheritdoc IMintableERC721
+    function burn(uint256 tokenId) external onlyOwner {
+        _burn(tokenId);
+        // Clear the token URI when burning
+        if (bytes(_tokenURIs[tokenId]).length != 0) {
+            delete _tokenURIs[tokenId];
+        }
+    }
+
+    /// @dev See {IERC721Metadata-tokenURI}.
+    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+        _requireOwned(tokenId);
+
+        string memory _tokenURI = _tokenURIs[tokenId];
+
+        // If there is a custom URI for this token, return it
+        if (bytes(_tokenURI).length > 0) {
+            return _tokenURI;
+        }
+
+        // Otherwise, fall back to the default behavior
+        return super.tokenURI(tokenId);
+    }
+
+    /// @dev Sets the token URI for a specific token
+    /// @param tokenId Token ID to set URI for
+    /// @param tokenURI_ URI to set
+    function _setTokenURI(uint256 tokenId, string memory tokenURI_) internal {
+        _tokenURIs[tokenId] = tokenURI_;
+    }
+}

--- a/src/protocol/BridgedTokenBase.sol
+++ b/src/protocol/BridgedTokenBase.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title BridgedTokenBase
+/// @notice Common base contract for all bridged tokens
+/// @dev Provides ownership control and original token tracking. Uses OpenZeppelin's Ownable for access control.
+abstract contract BridgedTokenBase is Ownable {
+    /// @notice Address of the original token on the source chain
+    address public immutable originalToken;
+
+    /// @dev Constructor sets the deployer (bridge) as owner and stores original token address
+    /// @param _originalToken Address of the original token on the source chain
+    constructor(address _originalToken) Ownable(msg.sender) {
+        originalToken = _originalToken;
+    }
+}

--- a/src/protocol/ERC1155Bridge.sol
+++ b/src/protocol/ERC1155Bridge.sol
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BridgedERC1155} from "./BridgedERC1155.sol";
+import {IERC1155Bridge} from "./IERC1155Bridge.sol";
+import {ISignalService} from "./ISignalService.sol";
+
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {IERC1155MetadataURI} from "@openzeppelin/contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol";
+import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+
+/// @title ERC1155Bridge
+/// @notice A decentralized bridge for ERC1155 tokens that allows anyone to initialize tokens
+/// @dev Uses a permissionless token initialization flow
+contract ERC1155Bridge is IERC1155Bridge, ReentrancyGuardTransient, IERC1155Receiver {
+    /// @dev Signal type constants to differentiate signal categories
+    bytes32 private constant INITIALIZATION_SIGNAL_PREFIX = keccak256("ERC1155_TOKEN_INITIALIZATION");
+    bytes32 private constant DEPOSIT_SIGNAL_PREFIX = keccak256("ERC1155_DEPOSIT");
+
+    mapping(bytes32 id => bool processed) private _processed;
+    mapping(address token => bool initialized) private _initializedTokens;
+    mapping(bytes32 key => address deployedToken) private _deployedTokens;
+    mapping(address token => bool isBridgedToken) private _isBridgedTokens;
+
+    /// Incremental nonce to generate unique deposit IDs.
+    uint256 private _globalDepositNonce;
+
+    ISignalService public immutable signalService;
+
+    /// @dev Trusted source of commitments in the `CommitmentStore` that the bridge will use to validate withdrawals
+    /// @dev This is the Anchor on L2 and the Checkpoint Tracker on the L1
+    address public immutable trustedCommitmentPublisher;
+
+    /// @dev The counterpart bridge contract on the other chain.
+    /// This is used to locate deposit signals inside the other chain's state root.
+    /// WARN: This address has no significance (and may be untrustworthy) on this chain.
+    address public immutable counterpart;
+
+    constructor(address _signalService, address _trustedCommitmentPublisher, address _counterpart) {
+        require(_signalService != address(0), "Empty signal service");
+        require(_trustedCommitmentPublisher != address(0), "Empty trusted publisher");
+        require(_counterpart != address(0), "Empty counterpart");
+
+        signalService = ISignalService(_signalService);
+        trustedCommitmentPublisher = _trustedCommitmentPublisher;
+        counterpart = _counterpart;
+    }
+
+    /// @inheritdoc IERC1155Receiver
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata) external pure returns (bytes4) {
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    /// @inheritdoc IERC1155Receiver
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IERC1155Receiver).interfaceId;
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function processed(bytes32 id) public view returns (bool) {
+        return _processed[id];
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function isTokenInitialized(address token) public view returns (bool) {
+        return _initializedTokens[token];
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function isInitializationProven(bytes32 id) public view returns (bool) {
+        return _processed[id];
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function getDeployedToken(address originalToken) public view returns (address) {
+        bytes32 key = keccak256(abi.encode(originalToken));
+        return _deployedTokens[key];
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function getInitializationId(TokenInitialization memory tokenInit) public pure returns (bytes32 id) {
+        return _generateInitializationId(tokenInit);
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function getDepositId(ERC1155Deposit memory erc1155Deposit) public pure returns (bytes32 id) {
+        return _generateDepositId(erc1155Deposit);
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function initializeToken(address token) external returns (bytes32 id) {
+        require(token != address(0), "Invalid token address");
+        require(!_initializedTokens[token], "Token already initialized");
+
+        // Read token URI (base URI for the collection)
+        string memory uri;
+        try IERC1155MetadataURI(token).uri(0) returns (string memory tokenUri) {
+            uri = tokenUri;
+        } catch {
+            // If uri call fails, use empty string
+            uri = "";
+        }
+
+        TokenInitialization memory tokenInit = TokenInitialization({originalToken: token, uri: uri});
+
+        id = _generateInitializationId(tokenInit);
+
+        // Mark token as initialized locally
+        _initializedTokens[token] = true;
+
+        // Send signal for cross-chain initialization
+        signalService.sendSignal(id);
+
+        emit TokenInitialized(id, tokenInit);
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function deployCounterpartToken(TokenInitialization memory tokenInit, uint256 height, bytes memory proof)
+        external
+        returns (address deployedToken)
+    {
+        bytes32 id = _generateInitializationId(tokenInit);
+        require(!_processed[id], InitializationAlreadyProven());
+
+        // Verify the initialization signal from the source chain
+        signalService.verifySignal(height, trustedCommitmentPublisher, counterpart, id, proof);
+
+        // Mark initialization as processed
+        _processed[id] = true;
+
+        // Deploy the bridged token
+        deployedToken = address(new BridgedERC1155(tokenInit.uri, tokenInit.originalToken));
+
+        // Store the mapping
+        bytes32 key = keccak256(abi.encode(tokenInit.originalToken));
+        _deployedTokens[key] = deployedToken;
+
+        // Mark as a bridged token deployed by this bridge
+        _isBridgedTokens[deployedToken] = true;
+
+        emit TokenInitializationProven(id, tokenInit, deployedToken);
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function deposit(address to, address localToken, uint256 tokenId, uint256 amount, address canceler)
+        external
+        nonReentrant
+        returns (bytes32 id)
+    {
+        // Check if token is initialized (for original tokens) or is a bridged token deployed by this bridge
+        require(_initializedTokens[localToken] || _isBridgedToken(localToken), TokenNotInitialized());
+
+        // Fetch the token URI for this specific token
+        string memory tokenURI_;
+        try IERC1155MetadataURI(localToken).uri(tokenId) returns (string memory uri) {
+            tokenURI_ = uri;
+        } catch {
+            // If uri call fails, use empty string
+            tokenURI_ = "";
+        }
+
+        // Determine the original token address
+        address originalToken;
+        if (_isBridgedToken(localToken)) {
+            // If depositing a bridged token, use its original token address
+            originalToken = BridgedERC1155(localToken).originalToken();
+        } else {
+            // If depositing an original token, use its address directly
+            originalToken = localToken;
+        }
+
+        ERC1155Deposit memory erc1155Deposit = ERC1155Deposit({
+            nonce: _globalDepositNonce,
+            from: msg.sender,
+            to: to,
+            localToken: originalToken,
+            tokenId: tokenId,
+            amount: amount,
+            tokenURI: tokenURI_,
+            canceler: canceler
+        });
+
+        id = _generateDepositId(erc1155Deposit);
+        unchecked {
+            ++_globalDepositNonce;
+        }
+
+        // Handle token transfer based on whether it's a bridged token or original token
+        IERC1155(localToken).safeTransferFrom(msg.sender, address(this), tokenId, amount, "");
+        if (_isBridgedToken(localToken)) {
+            // This is a bridged token being sent back to its origin, burn it
+            BridgedERC1155(localToken).burn(tokenId, amount);
+        }
+
+        // Send signal
+        signalService.sendSignal(id);
+        emit DepositMade(id, erc1155Deposit);
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function claimDeposit(ERC1155Deposit memory erc1155Deposit, uint256 height, bytes memory proof)
+        external
+        nonReentrant
+    {
+        bytes32 id = _claimDeposit(erc1155Deposit, erc1155Deposit.to, height, proof);
+        emit DepositClaimed(id, erc1155Deposit);
+    }
+
+    /// @inheritdoc IERC1155Bridge
+    function cancelDeposit(ERC1155Deposit memory erc1155Deposit, address claimee, uint256 height, bytes memory proof)
+        external
+        nonReentrant
+    {
+        require(msg.sender == erc1155Deposit.canceler, OnlyCanceler());
+
+        bytes32 id = _claimDeposit(erc1155Deposit, claimee, height, proof);
+
+        emit DepositCancelled(id, claimee);
+    }
+
+    function _claimDeposit(ERC1155Deposit memory erc1155Deposit, address to, uint256 height, bytes memory proof)
+        internal
+        returns (bytes32 id)
+    {
+        id = _generateDepositId(erc1155Deposit);
+        require(!processed(id), AlreadyClaimed());
+
+        signalService.verifySignal(height, trustedCommitmentPublisher, counterpart, id, proof);
+
+        _processed[id] = true;
+        _sendERC1155(erc1155Deposit, to);
+    }
+
+    /// @dev Function to transfer ERC1155 to the receiver.
+    /// @param erc1155Deposit The deposit information containing the original token address and tokenId
+    /// @param to Address to send the tokens to
+    function _sendERC1155(ERC1155Deposit memory erc1155Deposit, address to) internal {
+        // In a 1-1 bridge, use token mapping presence to determine mint vs transfer
+        bytes32 key = keccak256(abi.encode(erc1155Deposit.localToken));
+        address deployedToken = _deployedTokens[key];
+
+        if (deployedToken != address(0)) {
+            // We have a bridged token for this original token → mint it with metadata
+            if (bytes(erc1155Deposit.tokenURI).length > 0) {
+                BridgedERC1155(deployedToken).mintWithURI(
+                    to, erc1155Deposit.tokenId, erc1155Deposit.amount, erc1155Deposit.tokenURI, ""
+                );
+            } else {
+                BridgedERC1155(deployedToken).mint(to, erc1155Deposit.tokenId, erc1155Deposit.amount, "");
+            }
+        } else {
+            // No bridged token found → transfer the original token we're holding
+            IERC1155(erc1155Deposit.localToken).safeTransferFrom(
+                address(this), to, erc1155Deposit.tokenId, erc1155Deposit.amount, ""
+            );
+        }
+    }
+
+    /// @dev Checks if a token is a bridged token deployed by this bridge.
+    /// @param token The token address to check
+    /// @return true if the token is a bridged token deployed by this bridge
+    function _isBridgedToken(address token) internal view returns (bool) {
+        return _isBridgedTokens[token];
+    }
+
+    /// @dev Generates a unique ID for a token initialization.
+    /// @param tokenInit Token initialization to generate an ID for
+    function _generateInitializationId(TokenInitialization memory tokenInit) internal pure returns (bytes32) {
+        return keccak256(abi.encode(INITIALIZATION_SIGNAL_PREFIX, tokenInit));
+    }
+
+    /// @dev Generates a unique ID for a deposit.
+    /// @param erc1155Deposit Deposit to generate an ID for
+    function _generateDepositId(ERC1155Deposit memory erc1155Deposit) internal pure returns (bytes32) {
+        return keccak256(abi.encode(DEPOSIT_SIGNAL_PREFIX, erc1155Deposit));
+    }
+}

--- a/src/protocol/ERC20Bridge.sol
+++ b/src/protocol/ERC20Bridge.sol
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BridgedERC20} from "./BridgedERC20.sol";
+import {IERC20Bridge} from "./IERC20Bridge.sol";
+import {ISignalService} from "./ISignalService.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+
+/// @title ERC20Bridge
+/// @notice A decentralized bridge for ERC20 tokens that allows anyone to initialize tokens
+/// @dev Uses a permissionless token initialization flow
+contract ERC20Bridge is IERC20Bridge, ReentrancyGuardTransient {
+    using SafeERC20 for IERC20;
+
+    /// @dev Signal type constants to differentiate signal categories
+    bytes32 private constant INITIALIZATION_SIGNAL_PREFIX = keccak256("ERC20_TOKEN_INITIALIZATION");
+    bytes32 private constant DEPOSIT_SIGNAL_PREFIX = keccak256("ERC20_DEPOSIT");
+
+    mapping(bytes32 id => bool processed) private _processed;
+    mapping(address token => bool initialized) private _initializedTokens;
+    mapping(bytes32 key => address deployedToken) private _deployedTokens;
+    mapping(address token => bool isBridgedToken) private _isBridgedTokens;
+
+    /// Incremental nonce to generate unique deposit IDs.
+    uint256 private _globalDepositNonce;
+
+    ISignalService public immutable signalService;
+
+    /// @dev Trusted source of commitments in the `CommitmentStore` that the bridge will use to validate withdrawals
+    /// @dev This is the Anchor on L2 and the Checkpoint Tracker on the L1
+    address public immutable trustedCommitmentPublisher;
+
+    /// @dev The counterpart bridge contract on the other chain.
+    /// This is used to locate deposit signals inside the other chain's state root.
+    /// WARN: This address has no significance (and may be untrustworthy) on this chain.
+    address public immutable counterpart;
+
+    constructor(address _signalService, address _trustedCommitmentPublisher, address _counterpart) {
+        require(_signalService != address(0), "Empty signal service");
+        require(_trustedCommitmentPublisher != address(0), "Empty trusted publisher");
+        require(_counterpart != address(0), "Empty counterpart");
+
+        signalService = ISignalService(_signalService);
+        trustedCommitmentPublisher = _trustedCommitmentPublisher;
+        counterpart = _counterpart;
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function processed(bytes32 id) public view returns (bool) {
+        return _processed[id];
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function isTokenInitialized(address token) public view returns (bool) {
+        return _initializedTokens[token];
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function isInitializationProven(bytes32 id) public view returns (bool) {
+        return _processed[id];
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function getDeployedToken(address originalToken) public view returns (address) {
+        bytes32 key = keccak256(abi.encode(originalToken));
+        return _deployedTokens[key];
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function getInitializationId(TokenInitialization memory tokenInit) public pure returns (bytes32 id) {
+        return _generateInitializationId(tokenInit);
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function getDepositId(ERC20Deposit memory erc20Deposit) public pure returns (bytes32 id) {
+        return _generateDepositId(erc20Deposit);
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function initializeToken(address token) external returns (bytes32 id) {
+        require(token != address(0), "Invalid token address");
+        require(!_initializedTokens[token], "Token already initialized");
+
+        // Read token metadata with fallbacks for non-compliant tokens
+        string memory name;
+        string memory symbol;
+        uint8 decimals;
+
+        try IERC20Metadata(token).name() returns (string memory _name) {
+            name = _name;
+        } catch {
+            name = "Unknown Token Name";
+        }
+
+        try IERC20Metadata(token).symbol() returns (string memory _symbol) {
+            symbol = _symbol;
+        } catch {
+            symbol = "UNKNOWN";
+        }
+
+        try IERC20Metadata(token).decimals() returns (uint8 _decimals) {
+            decimals = _decimals;
+        } catch {
+            decimals = 18; // Standard default
+        }
+
+        TokenInitialization memory tokenInit =
+            TokenInitialization({originalToken: token, name: name, symbol: symbol, decimals: decimals});
+
+        id = _generateInitializationId(tokenInit);
+
+        // Mark token as initialized locally
+        _initializedTokens[token] = true;
+
+        // Send signal for cross-chain initialization
+        signalService.sendSignal(id);
+
+        emit TokenInitialized(id, tokenInit);
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function deployCounterpartToken(TokenInitialization memory tokenInit, uint256 height, bytes memory proof)
+        external
+        returns (address deployedToken)
+    {
+        bytes32 id = _generateInitializationId(tokenInit);
+        require(!_processed[id], InitializationAlreadyProven());
+
+        // Verify the initialization signal from the source chain
+        signalService.verifySignal(height, trustedCommitmentPublisher, counterpart, id, proof);
+
+        // Mark initialization as processed
+        _processed[id] = true;
+
+        // Deploy the bridged token
+        deployedToken =
+            address(new BridgedERC20(tokenInit.name, tokenInit.symbol, tokenInit.decimals, tokenInit.originalToken));
+
+        // Store the mapping
+        bytes32 key = keccak256(abi.encode(tokenInit.originalToken));
+        _deployedTokens[key] = deployedToken;
+
+        // Mark as a bridged token deployed by this bridge
+        _isBridgedTokens[deployedToken] = true;
+
+        emit TokenInitializationProven(id, tokenInit, deployedToken);
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function deposit(address to, address localToken, uint256 amount) external nonReentrant returns (bytes32 id) {
+        // Check if token is initialized (for original tokens) or is a bridged token deployed by this bridge
+        require(_initializedTokens[localToken] || _isBridgedToken(localToken), TokenNotInitialized());
+
+        // Determine the original token address
+        address originalToken;
+        if (_isBridgedToken(localToken)) {
+            // If depositing a bridged token, use its original token address
+            originalToken = BridgedERC20(localToken).originalToken();
+        } else {
+            // If depositing an original token, use its address directly
+            originalToken = localToken;
+        }
+
+        ERC20Deposit memory erc20Deposit = ERC20Deposit({
+            nonce: _globalDepositNonce,
+            from: msg.sender,
+            to: to,
+            localToken: originalToken,
+            amount: amount
+        });
+
+        id = _generateDepositId(erc20Deposit);
+        unchecked {
+            ++_globalDepositNonce;
+        }
+
+        // Handle token transfer based on whether it's a bridged token or original token
+        IERC20(localToken).safeTransferFrom(msg.sender, address(this), amount);
+        if (_isBridgedToken(localToken)) {
+            // This is a bridged token being sent back to its origin, burn it
+            BridgedERC20(localToken).burn(amount);
+        }
+
+        // Send signal
+        signalService.sendSignal(id);
+        emit DepositMade(id, erc20Deposit);
+    }
+
+    /// @inheritdoc IERC20Bridge
+    function claimDeposit(ERC20Deposit memory erc20Deposit, uint256 height, bytes memory proof) external nonReentrant {
+        bytes32 id = _claimDeposit(erc20Deposit, erc20Deposit.to, height, proof);
+        emit DepositClaimed(id, erc20Deposit);
+    }
+
+    function _claimDeposit(ERC20Deposit memory erc20Deposit, address to, uint256 height, bytes memory proof)
+        internal
+        returns (bytes32 id)
+    {
+        id = _generateDepositId(erc20Deposit);
+        require(!processed(id), AlreadyClaimed());
+
+        signalService.verifySignal(height, trustedCommitmentPublisher, counterpart, id, proof);
+
+        _processed[id] = true;
+        _sendERC20(erc20Deposit, to);
+    }
+
+    /// @dev Function to transfer ERC20 to the receiver.
+    /// @param erc20Deposit The deposit information containing the original token address
+    /// @param to Address to send the tokens to
+    function _sendERC20(ERC20Deposit memory erc20Deposit, address to) internal {
+        // In a 1-1 bridge, use token mapping presence to determine mint vs transfer
+        bytes32 key = keccak256(abi.encode(erc20Deposit.localToken));
+        address deployedToken = _deployedTokens[key];
+
+        if (deployedToken != address(0)) {
+            // We have a bridged token for this original token → mint it
+            BridgedERC20(deployedToken).mint(to, erc20Deposit.amount);
+        } else {
+            // No bridged token found → transfer the original token we're holding
+            IERC20(erc20Deposit.localToken).safeTransfer(to, erc20Deposit.amount);
+        }
+    }
+
+    /// @dev Checks if a token is a bridged token deployed by this bridge.
+    /// @param token The token address to check
+    /// @return true if the token is a bridged token deployed by this bridge
+    function _isBridgedToken(address token) internal view returns (bool) {
+        return _isBridgedTokens[token];
+    }
+
+    /// @dev Generates a unique ID for a token initialization.
+    /// @param tokenInit Token initialization to generate an ID for
+    function _generateInitializationId(TokenInitialization memory tokenInit) internal pure returns (bytes32) {
+        return keccak256(abi.encode(INITIALIZATION_SIGNAL_PREFIX, tokenInit));
+    }
+
+    /// @dev Generates a unique ID for a deposit.
+    /// @param erc20Deposit Deposit to generate an ID for
+    function _generateDepositId(ERC20Deposit memory erc20Deposit) internal pure returns (bytes32) {
+        return keccak256(abi.encode(DEPOSIT_SIGNAL_PREFIX, erc20Deposit));
+    }
+}

--- a/src/protocol/ERC721Bridge.sol
+++ b/src/protocol/ERC721Bridge.sol
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BridgedERC721} from "./BridgedERC721.sol";
+import {IERC721Bridge} from "./IERC721Bridge.sol";
+import {ISignalService} from "./ISignalService.sol";
+
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+
+/// @title ERC721Bridge
+/// @notice A decentralized bridge for ERC721 tokens that allows anyone to initialize tokens
+/// @dev Uses a permissionless token initialization flow
+contract ERC721Bridge is IERC721Bridge, ReentrancyGuardTransient, IERC721Receiver {
+    /// @dev Signal type constants to differentiate signal categories
+    bytes32 private constant INITIALIZATION_SIGNAL_PREFIX = keccak256("ERC721_TOKEN_INITIALIZATION");
+    bytes32 private constant DEPOSIT_SIGNAL_PREFIX = keccak256("ERC721_DEPOSIT");
+
+    mapping(bytes32 id => bool processed) private _processed;
+    mapping(address token => bool initialized) private _initializedTokens;
+    mapping(bytes32 key => address deployedToken) private _deployedTokens;
+    mapping(address token => bool isBridgedToken) private _isBridgedTokens;
+
+    /// Incremental nonce to generate unique deposit IDs.
+    uint256 private _globalDepositNonce;
+
+    ISignalService public immutable signalService;
+
+    /// @dev Trusted source of commitments in the `CommitmentStore` that the bridge will use to validate withdrawals
+    /// @dev This is the Anchor on L2 and the Checkpoint Tracker on the L1
+    address public immutable trustedCommitmentPublisher;
+
+    /// @dev The counterpart bridge contract on the other chain.
+    /// This is used to locate deposit signals inside the other chain's state root.
+    /// WARN: This address has no significance (and may be untrustworthy) on this chain.
+    address public immutable counterpart;
+
+    constructor(address _signalService, address _trustedCommitmentPublisher, address _counterpart) {
+        require(_signalService != address(0), "Empty signal service");
+        require(_trustedCommitmentPublisher != address(0), "Empty trusted publisher");
+        require(_counterpart != address(0), "Empty counterpart");
+
+        signalService = ISignalService(_signalService);
+        trustedCommitmentPublisher = _trustedCommitmentPublisher;
+        counterpart = _counterpart;
+    }
+
+    /// @inheritdoc IERC721Receiver
+    function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
+        return IERC721Receiver.onERC721Received.selector;
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function processed(bytes32 id) public view returns (bool) {
+        return _processed[id];
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function isTokenInitialized(address token) public view returns (bool) {
+        return _initializedTokens[token];
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function isInitializationProven(bytes32 id) public view returns (bool) {
+        return _processed[id];
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function getDeployedToken(address originalToken) public view returns (address) {
+        bytes32 key = keccak256(abi.encode(originalToken));
+        return _deployedTokens[key];
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function getInitializationId(TokenInitialization memory tokenInit) public pure returns (bytes32 id) {
+        return _generateInitializationId(tokenInit);
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function getDepositId(ERC721Deposit memory erc721Deposit) public pure returns (bytes32 id) {
+        return _generateDepositId(erc721Deposit);
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function initializeToken(address token) external returns (bytes32 id) {
+        require(token != address(0), "Invalid token address");
+        require(!_initializedTokens[token], "Token already initialized");
+
+        // Read token metadata with fallbacks for non-compliant tokens
+        string memory name;
+        string memory symbol;
+
+        try IERC721Metadata(token).name() returns (string memory _name) {
+            name = _name;
+        } catch {
+            name = "Unknown NFT Name";
+        }
+
+        try IERC721Metadata(token).symbol() returns (string memory _symbol) {
+            symbol = _symbol;
+        } catch {
+            symbol = "UNKNOWN";
+        }
+
+        TokenInitialization memory tokenInit = TokenInitialization({originalToken: token, name: name, symbol: symbol});
+
+        id = _generateInitializationId(tokenInit);
+
+        // Mark token as initialized locally
+        _initializedTokens[token] = true;
+
+        // Send signal for cross-chain initialization
+        signalService.sendSignal(id);
+
+        emit TokenInitialized(id, tokenInit);
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function deployCounterpartToken(TokenInitialization memory tokenInit, uint256 height, bytes memory proof)
+        external
+        returns (address deployedToken)
+    {
+        bytes32 id = _generateInitializationId(tokenInit);
+        require(!_processed[id], InitializationAlreadyProven());
+
+        // Verify the initialization signal from the source chain
+        signalService.verifySignal(height, trustedCommitmentPublisher, counterpart, id, proof);
+
+        // Mark initialization as processed
+        _processed[id] = true;
+
+        // Deploy the bridged token
+        deployedToken = address(new BridgedERC721(tokenInit.name, tokenInit.symbol, tokenInit.originalToken));
+
+        // Store the mapping
+        bytes32 key = keccak256(abi.encode(tokenInit.originalToken));
+        _deployedTokens[key] = deployedToken;
+
+        // Mark as a bridged token deployed by this bridge
+        _isBridgedTokens[deployedToken] = true;
+
+        emit TokenInitializationProven(id, tokenInit, deployedToken);
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function deposit(address to, address localToken, uint256 tokenId, address canceler)
+        external
+        nonReentrant
+        returns (bytes32 id)
+    {
+        // Check if token is initialized (for original tokens) or is a bridged token deployed by this bridge
+        require(_initializedTokens[localToken] || _isBridgedToken(localToken), TokenNotInitialized());
+
+        // Fetch the token URI for this specific token
+        string memory tokenURI_;
+        try IERC721Metadata(localToken).tokenURI(tokenId) returns (string memory uri) {
+            tokenURI_ = uri;
+        } catch {
+            // If tokenURI call fails, use empty string
+            tokenURI_ = "";
+        }
+
+        // Determine the original token address
+        address originalToken;
+        if (_isBridgedToken(localToken)) {
+            // If depositing a bridged token, use its original token address
+            originalToken = BridgedERC721(localToken).originalToken();
+        } else {
+            // If depositing an original token, use its address directly
+            originalToken = localToken;
+        }
+
+        ERC721Deposit memory erc721Deposit = ERC721Deposit({
+            nonce: _globalDepositNonce,
+            from: msg.sender,
+            to: to,
+            localToken: originalToken,
+            tokenId: tokenId,
+            tokenURI: tokenURI_,
+            canceler: canceler
+        });
+
+        id = _generateDepositId(erc721Deposit);
+        unchecked {
+            ++_globalDepositNonce;
+        }
+
+        // Handle token transfer based on whether it's a bridged token or original token
+        IERC721(localToken).safeTransferFrom(msg.sender, address(this), tokenId);
+        if (_isBridgedToken(localToken)) {
+            // This is a bridged token being sent back to its origin, burn it
+            BridgedERC721(localToken).burn(tokenId);
+        }
+
+        // Send signal
+        signalService.sendSignal(id);
+        emit DepositMade(id, erc721Deposit);
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function claimDeposit(ERC721Deposit memory erc721Deposit, uint256 height, bytes memory proof)
+        external
+        nonReentrant
+    {
+        bytes32 id = _claimDeposit(erc721Deposit, erc721Deposit.to, height, proof);
+        emit DepositClaimed(id, erc721Deposit);
+    }
+
+    /// @inheritdoc IERC721Bridge
+    function cancelDeposit(ERC721Deposit memory erc721Deposit, address claimee, uint256 height, bytes memory proof)
+        external
+        nonReentrant
+    {
+        require(msg.sender == erc721Deposit.canceler, OnlyCanceler());
+
+        bytes32 id = _claimDeposit(erc721Deposit, claimee, height, proof);
+
+        emit DepositCancelled(id, claimee);
+    }
+
+    function _claimDeposit(ERC721Deposit memory erc721Deposit, address to, uint256 height, bytes memory proof)
+        internal
+        returns (bytes32 id)
+    {
+        id = _generateDepositId(erc721Deposit);
+        require(!processed(id), AlreadyClaimed());
+
+        signalService.verifySignal(height, trustedCommitmentPublisher, counterpart, id, proof);
+
+        _processed[id] = true;
+        _sendERC721(erc721Deposit, to);
+    }
+
+    /// @dev Function to transfer ERC721 to the receiver.
+    /// @param erc721Deposit The deposit information containing the original token address and tokenId
+    /// @param to Address to send the token to
+    function _sendERC721(ERC721Deposit memory erc721Deposit, address to) internal {
+        // In a 1-1 bridge, use token mapping presence to determine mint vs transfer
+        bytes32 key = keccak256(abi.encode(erc721Deposit.localToken));
+        address deployedToken = _deployedTokens[key];
+
+        if (deployedToken != address(0)) {
+            // We have a bridged token for this original token → mint it with metadata
+            if (bytes(erc721Deposit.tokenURI).length > 0) {
+                BridgedERC721(deployedToken).mintWithURI(to, erc721Deposit.tokenId, erc721Deposit.tokenURI);
+            } else {
+                BridgedERC721(deployedToken).mint(to, erc721Deposit.tokenId);
+            }
+        } else {
+            // No bridged token found → transfer the original token we're holding
+            IERC721(erc721Deposit.localToken).safeTransferFrom(address(this), to, erc721Deposit.tokenId);
+        }
+    }
+
+    /// @dev Checks if a token is a bridged token deployed by this bridge.
+    /// @param token The token address to check
+    /// @return true if the token is a bridged token deployed by this bridge
+    function _isBridgedToken(address token) internal view returns (bool) {
+        return _isBridgedTokens[token];
+    }
+
+    /// @dev Generates a unique ID for a token initialization.
+    /// @param tokenInit Token initialization to generate an ID for
+    function _generateInitializationId(TokenInitialization memory tokenInit) internal pure returns (bytes32) {
+        return keccak256(abi.encode(INITIALIZATION_SIGNAL_PREFIX, tokenInit));
+    }
+
+    /// @dev Generates a unique ID for a deposit.
+    /// @param erc721Deposit Deposit to generate an ID for
+    function _generateDepositId(ERC721Deposit memory erc721Deposit) internal pure returns (bytes32) {
+        return keccak256(abi.encode(DEPOSIT_SIGNAL_PREFIX, erc721Deposit));
+    }
+}

--- a/src/protocol/IERC1155Bridge.sol
+++ b/src/protocol/IERC1155Bridge.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @dev Bridges ERC1155 tokens by creating and verifying ERC1155Deposits.
+///
+/// These can be created by calling the deposit function. Later, the receiver can
+/// claim the deposit on the destination chain by using a storage proof.
+interface IERC1155Bridge {
+    struct TokenInitialization {
+        // The original token address on the source chain
+        address originalToken;
+        // The base URI for the token collection
+        string uri;
+    }
+
+    struct ERC1155Deposit {
+        // The nonce of the deposit
+        uint256 nonce;
+        // The sender of the deposit
+        address from;
+        // The receiver of the deposit
+        address to;
+        // The original ERC1155 token address (always refers to the original token, not bridged)
+        address localToken;
+        // The token ID
+        uint256 tokenId;
+        // The amount of the deposit
+        uint256 amount;
+        // The token URI (metadata) for this specific token
+        string tokenURI;
+        // Address that is allowed to cancel the deposit on the destination chain (zero address means deposit is
+        // uncancellable)
+        address canceler;
+    }
+
+    /// @dev Emitted when a token is initialized on the source chain.
+    /// @param id The initialization id
+    /// @param initialization The token initialization data
+    event TokenInitialized(bytes32 indexed id, TokenInitialization initialization);
+
+    /// @dev Emitted when a token initialization is proven on the destination chain.
+    /// @param id The initialization id
+    /// @param initialization The token initialization data
+    /// @param deployedToken The address of the deployed bridged token
+    event TokenInitializationProven(
+        bytes32 indexed id, TokenInitialization initialization, address indexed deployedToken
+    );
+
+    /// @dev Emitted when a deposit is made.
+    /// @param id The deposit id
+    /// @param deposit The ERC1155 deposit
+    event DepositMade(bytes32 indexed id, ERC1155Deposit deposit);
+
+    /// @dev Emitted when a deposit is claimed.
+    /// @param id The deposit id
+    /// @param deposit The claimed ERC1155 deposit
+    event DepositClaimed(bytes32 indexed id, ERC1155Deposit deposit);
+
+    /// @dev Emitted when a deposit is cancelled.
+    /// @param id The deposit id
+    /// @param claimee The address that received the cancelled deposit
+    event DepositCancelled(bytes32 indexed id, address claimee);
+
+    /// @dev Failed to claim the deposit.
+    error FailedClaim();
+
+    /// @dev A deposit was already claimed.
+    error AlreadyClaimed();
+
+    /// @dev Only canceler can cancel a deposit.
+    error OnlyCanceler();
+
+    /// @dev Token has not been initialized for bridging.
+    error TokenNotInitialized();
+
+    /// @dev Token initialization has already been proven.
+    error InitializationAlreadyProven();
+
+    /// @dev Whether the deposit identified by `id` has been claimed or cancelled.
+    /// @param id The deposit id
+    function processed(bytes32 id) external view returns (bool);
+
+    /// @dev Whether a token has been initialized for bridging.
+    /// @param token The token address
+    function isTokenInitialized(address token) external view returns (bool);
+
+    /// @dev Whether a token initialization has been proven (on destination chain).
+    /// @param id The initialization id
+    function isInitializationProven(bytes32 id) external view returns (bool);
+
+    /// @dev Get the deployed token address for an original token (on destination chain).
+    /// @param originalToken The original token address
+    function getDeployedToken(address originalToken) external view returns (address);
+
+    /// @dev Token initialization identifier.
+    /// @param tokenInit The token initialization struct
+    function getInitializationId(TokenInitialization memory tokenInit) external pure returns (bytes32 id);
+
+    /// @dev ERC1155 Deposit identifier.
+    /// @param erc1155Deposit The ERC1155 deposit struct
+    function getDepositId(ERC1155Deposit memory erc1155Deposit) external view returns (bytes32 id);
+
+    /// @dev Initializes a token for bridging by reading its metadata and sending a signal.
+    /// @param token The ERC1155 token address to initialize
+    function initializeToken(address token) external returns (bytes32 id);
+
+    /// @dev Proves a token initialization from the source chain and deploys the bridged token.
+    /// @param tokenInit The token initialization data
+    /// @param height The height of the checkpoint on the source chain
+    /// @param proof Encoded proof of the initialization signal
+    function deployCounterpartToken(TokenInitialization memory tokenInit, uint256 height, bytes memory proof)
+        external
+        returns (address deployedToken);
+
+    /// @dev Creates an ERC1155 deposit
+    /// @param to The receiver of the deposit
+    /// @param localToken The ERC1155 token address
+    /// @param tokenId The token ID
+    /// @param amount The amount to deposit
+    /// @param canceler Address on the destination chain that is allowed to cancel the deposit (zero address means
+    /// deposit is uncancellable)
+    function deposit(address to, address localToken, uint256 tokenId, uint256 amount, address canceler)
+        external
+        returns (bytes32 id);
+
+    /// @dev Claims an ERC1155 deposit created by the sender (`from`) with `nonce`. The deposited tokens are
+    /// sent to the receiver (`to`) after verifying a storage proof.
+    /// @param erc1155Deposit The ERC1155 deposit struct
+    /// @param height The `height` of the checkpoint on the source chain (i.e. the block number or publicationId)
+    /// @param proof Encoded proof of the storage slot where the deposit is stored
+    function claimDeposit(ERC1155Deposit memory erc1155Deposit, uint256 height, bytes memory proof) external;
+
+    /// @dev Initiates a cancel on the deposit, must be called by the canceler on the destination chain.
+    /// @param erc1155Deposit The ERC1155 deposit struct
+    /// @param claimee The address that will receive the cancelled deposit
+    /// @param height The `height` of the checkpoint on the source chain (i.e. the block number or publicationId)
+    /// @param proof Encoded proof of the storage slot where the deposit is stored
+    function cancelDeposit(ERC1155Deposit memory erc1155Deposit, address claimee, uint256 height, bytes memory proof)
+        external;
+}

--- a/src/protocol/IERC20Bridge.sol
+++ b/src/protocol/IERC20Bridge.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @dev Bridges ERC20 tokens by creating and verifying ERC20Deposits.
+///
+/// These can be created by calling the deposit function. Later, the receiver can
+/// claim the deposit on the destination chain by using a storage proof.
+interface IERC20Bridge {
+    struct TokenInitialization {
+        // The original token address on the source chain
+        address originalToken;
+        // The token name
+        string name;
+        // The token symbol
+        string symbol;
+        // The token decimals
+        uint8 decimals;
+    }
+
+    struct ERC20Deposit {
+        // The nonce of the deposit
+        uint256 nonce;
+        // The sender of the deposit
+        address from;
+        // The receiver of the deposit
+        address to;
+        // The original ERC20 token address (always refers to the original token, not bridged)
+        address localToken;
+        // The amount of the deposit
+        uint256 amount;
+    }
+
+    /// @dev Emitted when a token is initialized on the source chain.
+    /// @param id The initialization id
+    /// @param initialization The token initialization data
+    event TokenInitialized(bytes32 indexed id, TokenInitialization initialization);
+
+    /// @dev Emitted when a token initialization is proven on the destination chain.
+    /// @param id The initialization id
+    /// @param initialization The token initialization data
+    /// @param deployedToken The address of the deployed bridged token
+    event TokenInitializationProven(
+        bytes32 indexed id, TokenInitialization initialization, address indexed deployedToken
+    );
+
+    /// @dev Emitted when a deposit is made.
+    /// @param id The deposit id
+    /// @param deposit The ERC20 deposit
+    event DepositMade(bytes32 indexed id, ERC20Deposit deposit);
+
+    /// @dev Emitted when a deposit is claimed.
+    /// @param id The deposit id
+    /// @param deposit The claimed ERC20 deposit
+    event DepositClaimed(bytes32 indexed id, ERC20Deposit deposit);
+
+    /// @dev Failed to claim the deposit.
+    error FailedClaim();
+
+    /// @dev A deposit was already claimed.
+    error AlreadyClaimed();
+
+    /// @dev Token has not been initialized for bridging.
+    error TokenNotInitialized();
+
+    /// @dev Token initialization has already been proven.
+    error InitializationAlreadyProven();
+
+    /// @dev Whether the deposit identified by `id` has been claimed or cancelled.
+    /// @param id The deposit id
+    function processed(bytes32 id) external view returns (bool);
+
+    /// @dev Whether a token has been initialized for bridging.
+    /// @param token The token address
+    function isTokenInitialized(address token) external view returns (bool);
+
+    /// @dev Whether a token initialization has been proven (on destination chain).
+    /// @param id The initialization id
+    function isInitializationProven(bytes32 id) external view returns (bool);
+
+    /// @dev Get the deployed token address for an original token (on destination chain).
+    /// @param originalToken The original token address
+    function getDeployedToken(address originalToken) external view returns (address);
+
+    /// @dev Token initialization identifier.
+    /// @param tokenInit The token initialization struct
+    function getInitializationId(TokenInitialization memory tokenInit) external pure returns (bytes32 id);
+
+    /// @dev ERC20 Deposit identifier.
+    /// @param erc20Deposit The ERC20 deposit struct
+    function getDepositId(ERC20Deposit memory erc20Deposit) external pure returns (bytes32 id);
+
+    /// @dev Initializes a token for bridging by reading its metadata and sending a signal.
+    /// @param token The ERC20 token address to initialize
+    function initializeToken(address token) external returns (bytes32 id);
+
+    /// @dev Proves a token initialization from the source chain and deploys the bridged token.
+    /// @param tokenInit The token initialization data
+    /// @param height The height of the checkpoint on the source chain
+    /// @param proof Encoded proof of the initialization signal
+    function deployCounterpartToken(TokenInitialization memory tokenInit, uint256 height, bytes memory proof)
+        external
+        returns (address deployedToken);
+
+    /// @dev Creates an ERC20 deposit
+    /// @param to The receiver of the deposit
+    /// @param localToken The ERC20 token address
+    /// @param amount The amount to deposit
+    function deposit(address to, address localToken, uint256 amount) external returns (bytes32 id);
+
+    /// @dev Claims an ERC20 deposit created by the sender (`from`) with `nonce`. The deposited tokens are
+    /// sent to the receiver (`to`) after verifying a storage proof.
+    /// @param erc20Deposit The ERC20 deposit struct
+    /// @param height The `height` of the checkpoint on the source chain (i.e. the block number or publicationId)
+    /// @param proof Encoded proof of the storage slot where the deposit is stored
+    function claimDeposit(ERC20Deposit memory erc20Deposit, uint256 height, bytes memory proof) external;
+}

--- a/src/protocol/IERC721Bridge.sol
+++ b/src/protocol/IERC721Bridge.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @dev Bridges ERC721 tokens by creating and verifying ERC721Deposits.
+///
+/// These can be created by calling the deposit function. Later, the receiver can
+/// claim the deposit on the destination chain by using a storage proof.
+interface IERC721Bridge {
+    struct TokenInitialization {
+        // The original token address on the source chain
+        address originalToken;
+        // The token name
+        string name;
+        // The token symbol
+        string symbol;
+    }
+
+    struct ERC721Deposit {
+        // The nonce of the deposit
+        uint256 nonce;
+        // The sender of the deposit
+        address from;
+        // The receiver of the deposit
+        address to;
+        // The original ERC721 token address (always refers to the original token, not bridged)
+        address localToken;
+        // The token ID
+        uint256 tokenId;
+        // The token URI (metadata) for this specific token
+        string tokenURI;
+        // Address that is allowed to cancel the deposit on the destination chain (zero address means deposit is
+        // uncancellable)
+        address canceler;
+    }
+
+    /// @dev Emitted when a token is initialized on the source chain.
+    /// @param id The initialization id
+    /// @param initialization The token initialization data
+    event TokenInitialized(bytes32 indexed id, TokenInitialization initialization);
+
+    /// @dev Emitted when a token initialization is proven on the destination chain.
+    /// @param id The initialization id
+    /// @param initialization The token initialization data
+    /// @param deployedToken The address of the deployed bridged token
+    event TokenInitializationProven(
+        bytes32 indexed id, TokenInitialization initialization, address indexed deployedToken
+    );
+
+    /// @dev Emitted when a deposit is made.
+    /// @param id The deposit id
+    /// @param deposit The ERC721 deposit
+    event DepositMade(bytes32 indexed id, ERC721Deposit deposit);
+
+    /// @dev Emitted when a deposit is claimed.
+    /// @param id The deposit id
+    /// @param deposit The claimed ERC721 deposit
+    event DepositClaimed(bytes32 indexed id, ERC721Deposit deposit);
+
+    /// @dev Emitted when a deposit is cancelled.
+    /// @param id The deposit id
+    /// @param claimee The address that received the cancelled deposit
+    event DepositCancelled(bytes32 indexed id, address claimee);
+
+    /// @dev Failed to claim the deposit.
+    error FailedClaim();
+
+    /// @dev A deposit was already claimed.
+    error AlreadyClaimed();
+
+    /// @dev Only canceler can cancel a deposit.
+    error OnlyCanceler();
+
+    /// @dev Token has not been initialized for bridging.
+    error TokenNotInitialized();
+
+    /// @dev Token initialization has already been proven.
+    error InitializationAlreadyProven();
+
+    /// @dev Whether the deposit identified by `id` has been claimed or cancelled.
+    /// @param id The deposit id
+    function processed(bytes32 id) external view returns (bool);
+
+    /// @dev Whether a token has been initialized for bridging.
+    /// @param token The token address
+    function isTokenInitialized(address token) external view returns (bool);
+
+    /// @dev Whether a token initialization has been proven (on destination chain).
+    /// @param id The initialization id
+    function isInitializationProven(bytes32 id) external view returns (bool);
+
+    /// @dev Get the deployed token address for an original token (on destination chain).
+    /// @param originalToken The original token address
+    function getDeployedToken(address originalToken) external view returns (address);
+
+    /// @dev Token initialization identifier.
+    /// @param tokenInit The token initialization struct
+    function getInitializationId(TokenInitialization memory tokenInit) external pure returns (bytes32 id);
+
+    /// @dev ERC721 Deposit identifier.
+    /// @param erc721Deposit The ERC721 deposit struct
+    function getDepositId(ERC721Deposit memory erc721Deposit) external view returns (bytes32 id);
+
+    /// @dev Initializes a token for bridging by reading its metadata and sending a signal.
+    /// @param token The ERC721 token address to initialize
+    function initializeToken(address token) external returns (bytes32 id);
+
+    /// @dev Proves a token initialization from the source chain and deploys the bridged token.
+    /// @param tokenInit The token initialization data
+    /// @param height The height of the checkpoint on the source chain
+    /// @param proof Encoded proof of the initialization signal
+    function deployCounterpartToken(TokenInitialization memory tokenInit, uint256 height, bytes memory proof)
+        external
+        returns (address deployedToken);
+
+    /// @dev Creates an ERC721 deposit
+    /// @param to The receiver of the deposit
+    /// @param localToken The ERC721 token address
+    /// @param tokenId The token ID to deposit
+    /// @param canceler Address on the destination chain that is allowed to cancel the deposit (zero address means
+    /// deposit is uncancellable)
+    function deposit(address to, address localToken, uint256 tokenId, address canceler) external returns (bytes32 id);
+
+    /// @dev Claims an ERC721 deposit created by the sender (`from`) with `nonce`. The deposited token is
+    /// sent to the receiver (`to`) after verifying a storage proof.
+    /// @param erc721Deposit The ERC721 deposit struct
+    /// @param height The `height` of the checkpoint on the source chain (i.e. the block number or publicationId)
+    /// @param proof Encoded proof of the storage slot where the deposit is stored
+    function claimDeposit(ERC721Deposit memory erc721Deposit, uint256 height, bytes memory proof) external;
+
+    /// @dev Initiates a cancel on the deposit, must be called by the canceler on the destination chain.
+    /// @param erc721Deposit The ERC721 deposit struct
+    /// @param claimee The address that will receive the cancelled deposit
+    /// @param height The `height` of the checkpoint on the source chain (i.e. the block number or publicationId)
+    /// @param proof Encoded proof of the storage slot where the deposit is stored
+    function cancelDeposit(ERC721Deposit memory erc721Deposit, address claimee, uint256 height, bytes memory proof)
+        external;
+}

--- a/src/protocol/IMintable.sol
+++ b/src/protocol/IMintable.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+interface IMintableERC20 is IERC20 {
+    function mint(address to, uint256 amount) external;
+    function burn(uint256 amount) external;
+}
+
+interface IMintableERC721 is IERC721 {
+    function mint(address to, uint256 tokenId) external;
+    function burn(uint256 tokenId) external;
+}
+
+interface IMintableERC1155 is IERC1155 {
+    function mint(address to, uint256 id, uint256 amount, bytes memory data) external;
+    function burn(uint256 id, uint256 amount) external;
+}

--- a/test/ERC1155Bridge/Basic.t.sol
+++ b/test/ERC1155Bridge/Basic.t.sol
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BridgedERC1155} from "../../src/protocol/BridgedERC1155.sol";
+import "forge-std/Test.sol";
+import {ERC1155Bridge} from "src/protocol/ERC1155Bridge.sol";
+import {IERC1155Bridge} from "src/protocol/IERC1155Bridge.sol";
+import {ISignalService} from "src/protocol/ISignalService.sol";
+import {MockERC1155} from "test/mocks/MockERC1155.sol";
+import {MockSignalService} from "test/mocks/MockSignalService.sol";
+
+contract ERC1155BridgeTest is Test {
+    ERC1155Bridge bridge;
+    MockSignalService signalService;
+    MockERC1155 token;
+    address trustedPublisher = address(0x123);
+    address counterpart = address(0x456);
+    address alice = address(0xA11CE);
+    address bob = address(0xB0B);
+    uint256 tokenId = 1;
+
+    function setUp() public {
+        signalService = new MockSignalService();
+        bridge = new ERC1155Bridge(address(signalService), trustedPublisher, counterpart);
+        token = new MockERC1155();
+        token.mint(alice, tokenId, 100, "");
+        vm.prank(alice);
+        token.setApprovalForAll(address(bridge), true);
+    }
+
+    function testInitializeToken() public {
+        vm.prank(alice);
+        bytes32 id = bridge.initializeToken(address(token));
+
+        assertTrue(bridge.isTokenInitialized(address(token)));
+        assertEq(signalService.lastSignalId(), id);
+    }
+
+    function testCannotInitializeTokenTwice() public {
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.expectRevert("Token already initialized");
+        vm.prank(bob);
+        bridge.initializeToken(address(token));
+    }
+
+    function testDeployCounterpartToken() public {
+        // First initialize on source chain
+        vm.prank(alice);
+        bytes32 id = bridge.initializeToken(address(token));
+
+        // Prepare initialization data for destination chain
+        IERC1155Bridge.TokenInitialization memory tokenInit = IERC1155Bridge.TokenInitialization({
+            originalToken: address(token),
+            uri: "https://example.com/metadata/0.json"
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        // Prove initialization and deploy bridged token
+        address deployedToken = bridge.deployCounterpartToken(tokenInit, height, proof);
+
+        assertTrue(bridge.isInitializationProven(id));
+        assertEq(bridge.getDeployedToken(address(token)), deployedToken);
+
+        // Check that the deployed token has correct metadata
+        BridgedERC1155 bridgedToken = BridgedERC1155(deployedToken);
+        assertEq(bridgedToken.owner(), address(bridge));
+        assertEq(bridgedToken.originalToken(), address(token));
+    }
+
+    function testCannotProveInitializationTwice() public {
+        // First initialize
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        IERC1155Bridge.TokenInitialization memory tokenInit = IERC1155Bridge.TokenInitialization({
+            originalToken: address(token),
+            uri: "https://example.com/metadata/0.json"
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.deployCounterpartToken(tokenInit, height, proof);
+
+        vm.expectRevert(IERC1155Bridge.InitializationAlreadyProven.selector);
+        bridge.deployCounterpartToken(tokenInit, height, proof);
+    }
+
+    function testDeposit() public {
+        // Initialize token first
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bytes32 id = bridge.deposit(bob, address(token), tokenId, 50, address(0));
+        assertFalse(bridge.processed(id));
+        assertEq(token.balanceOf(address(bridge), tokenId), 50);
+        assertEq(token.balanceOf(alice, tokenId), 50);
+    }
+
+    function testCannotDepositUninitializedToken() public {
+        vm.expectRevert(IERC1155Bridge.TokenNotInitialized.selector);
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, 50, address(0));
+    }
+
+    function testClaimDeposit() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bytes32 id = bridge.deposit(bob, address(token), tokenId, 50, address(0));
+
+        IERC1155Bridge.ERC1155Deposit memory deposit = IERC1155Bridge.ERC1155Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            amount: 50,
+            tokenURI: "https://example.com/metadata/1.json",
+            canceler: address(0)
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.claimDeposit(deposit, height, proof);
+
+        assertTrue(bridge.processed(id));
+        assertEq(token.balanceOf(bob, tokenId), 50);
+        assertEq(token.balanceOf(address(bridge), tokenId), 0);
+    }
+
+    function testCancelDeposit() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        address canceler = makeAddr("canceler");
+        vm.prank(alice);
+        bytes32 id = bridge.deposit(bob, address(token), tokenId, 50, canceler);
+
+        IERC1155Bridge.ERC1155Deposit memory deposit = IERC1155Bridge.ERC1155Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            amount: 50,
+            tokenURI: "https://example.com/metadata/1.json",
+            canceler: canceler
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        vm.prank(canceler);
+        bridge.cancelDeposit(deposit, alice, height, proof);
+
+        assertTrue(bridge.processed(id));
+        assertEq(token.balanceOf(alice, tokenId), 100); // back to original
+        assertEq(token.balanceOf(address(bridge), tokenId), 0);
+    }
+
+    function testCannotCancelIfNotCanceler() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        address canceler = makeAddr("canceler");
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, 50, canceler);
+
+        IERC1155Bridge.ERC1155Deposit memory deposit = IERC1155Bridge.ERC1155Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            amount: 50,
+            tokenURI: "https://example.com/metadata/1.json",
+            canceler: canceler
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        vm.expectRevert(IERC1155Bridge.OnlyCanceler.selector);
+        vm.prank(address(0xBAD));
+        bridge.cancelDeposit(deposit, alice, height, proof);
+    }
+
+    function testCannotClaimAlreadyClaimed() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, 50, address(0));
+
+        IERC1155Bridge.ERC1155Deposit memory deposit = IERC1155Bridge.ERC1155Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            amount: 50,
+            tokenURI: "https://example.com/metadata/1.json",
+            canceler: address(0)
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.claimDeposit(deposit, height, proof);
+
+        vm.expectRevert(IERC1155Bridge.AlreadyClaimed.selector);
+        bridge.claimDeposit(deposit, height, proof);
+    }
+
+    function testCannotCancelAlreadyClaimed() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        address canceler = makeAddr("canceler");
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, 50, canceler);
+
+        IERC1155Bridge.ERC1155Deposit memory deposit = IERC1155Bridge.ERC1155Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            amount: 50,
+            tokenURI: "https://example.com/metadata/1.json",
+            canceler: canceler
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.claimDeposit(deposit, height, proof);
+
+        vm.expectRevert(IERC1155Bridge.AlreadyClaimed.selector);
+        vm.prank(canceler);
+        bridge.cancelDeposit(deposit, alice, height, proof);
+    }
+
+    function testCannotCancelIfNoCanceler() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, 50, address(0));
+
+        IERC1155Bridge.ERC1155Deposit memory deposit = IERC1155Bridge.ERC1155Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            amount: 50,
+            tokenURI: "https://example.com/metadata/1.json",
+            canceler: address(0)
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        vm.expectRevert(IERC1155Bridge.OnlyCanceler.selector);
+        vm.prank(makeAddr("random"));
+        bridge.cancelDeposit(deposit, alice, height, proof);
+    }
+
+    function testMetadataPropagation() public {
+        // Create two separate bridge instances to simulate different chains
+        ERC1155Bridge bridge2 = new ERC1155Bridge(address(signalService), trustedPublisher, counterpart);
+
+        // Initialize token on chain 1
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        // Prove initialization on chain 2 (simulating it came from chain 1)
+        IERC1155Bridge.TokenInitialization memory tokenInit = IERC1155Bridge.TokenInitialization({
+            originalToken: address(token),
+            uri: "https://example.com/metadata/0.json"
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        address bridgedToken = bridge2.deployCounterpartToken(tokenInit, height, proof);
+
+        // Simulate bridging: deposit on chain 1, claim on chain 2
+        vm.prank(alice);
+        bridge.deposit(alice, address(token), tokenId, 25, address(0));
+
+        // For the claim, simulate that this deposit came from chain 1
+        IERC1155Bridge.ERC1155Deposit memory deposit = IERC1155Bridge.ERC1155Deposit({
+            nonce: 0,
+            from: alice,
+            to: alice,
+            localToken: address(token),
+            tokenId: tokenId,
+            amount: 25,
+            tokenURI: "https://example.com/metadata/1.json",
+            canceler: address(0)
+        });
+
+        // Claim on chain 2 (mints bridged token with metadata)
+        bridge2.claimDeposit(deposit, height, proof);
+
+        // Verify that the bridged token has the correct metadata
+        BridgedERC1155 bridgedNFT = BridgedERC1155(bridgedToken);
+        assertEq(bridgedNFT.balanceOf(alice, tokenId), 25);
+        assertEq(bridgedNFT.uri(tokenId), "https://example.com/metadata/1.json");
+
+        // Verify collection info is also correct
+        assertEq(bridgedNFT.owner(), address(bridge2));
+        assertEq(bridgedNFT.originalToken(), address(token));
+    }
+}

--- a/test/ERC20Bridge/Basic.t.sol
+++ b/test/ERC20Bridge/Basic.t.sol
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BridgedERC20} from "../../src/protocol/BridgedERC20.sol";
+import "forge-std/Test.sol";
+import {ERC20Bridge} from "src/protocol/ERC20Bridge.sol";
+import {IERC20Bridge} from "src/protocol/IERC20Bridge.sol";
+import {ISignalService} from "src/protocol/ISignalService.sol";
+
+import {MockBrokenERC20} from "test/mocks/MockBrokenERC20.sol";
+import {MockERC20} from "test/mocks/MockERC20.sol";
+import {MockMaliciousERC20} from "test/mocks/MockMaliciousERC20.sol";
+import {MockSignalService} from "test/mocks/MockSignalService.sol";
+
+contract ERC20BridgeTest is Test {
+    ERC20Bridge bridge;
+    MockSignalService signalService;
+    MockERC20 token;
+    address trustedPublisher = address(0x123);
+    address counterpart = address(0x456);
+    address alice = address(0xA11CE);
+    address bob = address(0xB0B);
+
+    function setUp() public {
+        signalService = new MockSignalService();
+        bridge = new ERC20Bridge(address(signalService), trustedPublisher, counterpart);
+        token = new MockERC20("Test Token", "TEST");
+        token.mint(alice, 1000);
+        vm.prank(alice);
+        token.approve(address(bridge), type(uint256).max);
+    }
+
+    function testInitializeToken() public {
+        vm.prank(alice);
+        bytes32 id = bridge.initializeToken(address(token));
+
+        assertTrue(bridge.isTokenInitialized(address(token)));
+        assertEq(signalService.lastSignalId(), id);
+    }
+
+    function testCannotInitializeTokenTwice() public {
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.expectRevert("Token already initialized");
+        vm.prank(bob);
+        bridge.initializeToken(address(token));
+    }
+
+    function testDeployCounterpartToken() public {
+        // First initialize on source chain
+        vm.prank(alice);
+        bytes32 id = bridge.initializeToken(address(token));
+
+        // Prepare initialization data for destination chain
+        IERC20Bridge.TokenInitialization memory tokenInit = IERC20Bridge.TokenInitialization({
+            originalToken: address(token),
+            name: "Test Token",
+            symbol: "TEST",
+            decimals: 18
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        // Prove initialization and deploy bridged token
+        address deployedToken = bridge.deployCounterpartToken(tokenInit, height, proof);
+
+        assertTrue(bridge.isInitializationProven(id));
+        assertEq(bridge.getDeployedToken(address(token)), deployedToken);
+
+        // Check that the deployed token has correct metadata
+        BridgedERC20 bridgedToken = BridgedERC20(deployedToken);
+        assertEq(bridgedToken.name(), "Test Token");
+        assertEq(bridgedToken.symbol(), "TEST");
+        assertEq(bridgedToken.decimals(), 18);
+        assertEq(bridgedToken.owner(), address(bridge));
+        assertEq(bridgedToken.originalToken(), address(token));
+    }
+
+    function testCannotProveInitializationTwice() public {
+        // First initialize
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        IERC20Bridge.TokenInitialization memory tokenInit = IERC20Bridge.TokenInitialization({
+            originalToken: address(token),
+            name: "Test Token",
+            symbol: "TEST",
+            decimals: 18
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.deployCounterpartToken(tokenInit, height, proof);
+
+        vm.expectRevert(IERC20Bridge.InitializationAlreadyProven.selector);
+        bridge.deployCounterpartToken(tokenInit, height, proof);
+    }
+
+    function testDeposit() public {
+        // Initialize token first
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), 100);
+        assertEq(token.balanceOf(address(bridge)), 100);
+        assertEq(token.balanceOf(alice), 900);
+    }
+
+    function testCannotDepositUninitializedToken() public {
+        vm.expectRevert(IERC20Bridge.TokenNotInitialized.selector);
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), 100);
+    }
+
+    function testClaimDeposit() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bytes32 id = bridge.deposit(bob, address(token), 100);
+
+        IERC20Bridge.ERC20Deposit memory deposit =
+            IERC20Bridge.ERC20Deposit({nonce: 0, from: alice, to: bob, localToken: address(token), amount: 100});
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.claimDeposit(deposit, height, proof);
+
+        assertTrue(bridge.processed(id));
+        assertEq(token.balanceOf(bob), 100);
+        assertEq(token.balanceOf(address(bridge)), 0);
+    }
+
+    function testCannotClaimAlreadyClaimed() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), 100);
+
+        IERC20Bridge.ERC20Deposit memory deposit =
+            IERC20Bridge.ERC20Deposit({nonce: 0, from: alice, to: bob, localToken: address(token), amount: 100});
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.claimDeposit(deposit, height, proof);
+
+        vm.expectRevert(IERC20Bridge.AlreadyClaimed.selector);
+        bridge.claimDeposit(deposit, height, proof);
+    }
+
+    function testBridgedTokenDeposit() public {
+        // Create two separate bridge instances to simulate different chains
+        ERC20Bridge bridge2 = new ERC20Bridge(address(signalService), trustedPublisher, counterpart);
+
+        // Initialize token on chain 1
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        // Prove initialization on chain 2 (simulating it came from chain 1)
+        IERC20Bridge.TokenInitialization memory tokenInit = IERC20Bridge.TokenInitialization({
+            originalToken: address(token),
+            name: "Test Token",
+            symbol: "TEST",
+            decimals: 18
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        address bridgedToken = bridge2.deployCounterpartToken(tokenInit, height, proof);
+
+        // Simulate bridging: deposit on chain 1, claim on chain 2
+        vm.prank(alice);
+        bytes32 depositId = bridge.deposit(alice, address(token), 200);
+
+        // For the claim, simulate that this deposit came from chain 1
+        IERC20Bridge.ERC20Deposit memory deposit =
+            IERC20Bridge.ERC20Deposit({nonce: 0, from: alice, to: alice, localToken: address(token), amount: 200});
+
+        // Claim on chain 2 (mints bridged tokens)
+        bridge2.claimDeposit(deposit, height, proof);
+
+        // Now alice has bridged tokens on chain 2
+        assertEq(BridgedERC20(bridgedToken).balanceOf(alice), 200);
+
+        // Alice deposits bridged tokens back to chain 1
+        vm.prank(alice);
+        BridgedERC20(bridgedToken).approve(address(bridge2), 100);
+
+        vm.prank(alice);
+        bridge2.deposit(bob, bridgedToken, 100);
+
+        // Bridged tokens should be burned (total supply decreases)
+        assertEq(BridgedERC20(bridgedToken).balanceOf(alice), 100);
+        assertEq(BridgedERC20(bridgedToken).totalSupply(), 100);
+    }
+
+    function testBrokenTokenMetadata() public {
+        // Deploy a broken token that reverts on metadata calls
+        MockBrokenERC20 brokenToken = new MockBrokenERC20();
+
+        // Initialize should work with fallback values
+        vm.prank(alice);
+        bytes32 id = bridge.initializeToken(address(brokenToken));
+
+        // Verify the token was initialized
+        assertTrue(bridge.isTokenInitialized(address(brokenToken)));
+
+        // Get the initialization to check fallback values were used
+        IERC20Bridge.TokenInitialization memory tokenInit = IERC20Bridge.TokenInitialization({
+            originalToken: address(brokenToken),
+            name: "Unknown Token Name", // Should use fallback
+            symbol: "UNKNOWN", // Should use fallback
+            decimals: 18 // Should use fallback
+        });
+
+        bytes32 expectedId = bridge.getInitializationId(tokenInit);
+        assertEq(id, expectedId);
+
+        // Should be able to prove initialization with fallback values
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        address deployedToken = bridge.deployCounterpartToken(tokenInit, height, proof);
+
+        // Verify the bridged token was deployed with fallback metadata
+        assertEq(BridgedERC20(deployedToken).name(), "Unknown Token Name");
+        assertEq(BridgedERC20(deployedToken).symbol(), "UNKNOWN");
+        assertEq(BridgedERC20(deployedToken).decimals(), 18);
+    }
+
+    function testSignalIDDifferentiation() public {
+        // Deploy and initialize token
+        vm.prank(alice);
+        bytes32 initId = bridge.initializeToken(address(token));
+
+        // Create a deposit (alice already has tokens and approval from setUp)
+        vm.prank(alice);
+        bytes32 depositId = bridge.deposit(alice, address(token), 100);
+
+        // Verify the signal IDs are different
+        assertNotEq(initId, depositId, "Initialization and deposit IDs should be different");
+
+        // Verify the IDs are deterministic (same inputs = same outputs)
+        IERC20Bridge.TokenInitialization memory tokenInit = IERC20Bridge.TokenInitialization({
+            originalToken: address(token),
+            name: "Test Token",
+            symbol: "TEST",
+            decimals: 18
+        });
+        bytes32 expectedInitId = bridge.getInitializationId(tokenInit);
+        assertEq(initId, expectedInitId, "Initialization ID should be deterministic");
+    }
+
+    function testMaliciousTokenRejection() public {
+        // Deploy a malicious token that could try to spoof bridge functionality
+        MockMaliciousERC20 maliciousToken = new MockMaliciousERC20(address(bridge));
+
+        // Verify the malicious token still tries to spoof (even though bridge() function no longer exists in real
+        // bridged tokens)
+        assertEq(maliciousToken.bridge(), address(bridge), "Malicious token should spoof bridge address");
+
+        // Transfer some malicious tokens to alice
+        maliciousToken.transfer(alice, 100);
+
+        // Try to deposit the malicious token - should fail because it's not actually a bridged token
+        vm.startPrank(alice);
+        maliciousToken.approve(address(bridge), 100);
+
+        // This should revert because the malicious token is not in the _isBridgedTokens mapping
+        vm.expectRevert(); // TokenNotInitialized()
+        bridge.deposit(alice, address(maliciousToken), 100);
+
+        vm.stopPrank();
+
+        // The malicious token is correctly rejected because bridge now uses secure mapping-based validation
+        // rather than calling external functions that could be spoofed
+    }
+
+    function testBridgedTokenBaseFeatures() public {
+        // Initialize and prove token initialization
+        MockERC20 originalToken = new MockERC20("Original Token", "ORIG");
+        bridge.initializeToken(address(originalToken));
+
+        IERC20Bridge.TokenInitialization memory tokenInit = IERC20Bridge.TokenInitialization({
+            originalToken: address(originalToken),
+            name: "Original Token",
+            symbol: "ORIG",
+            decimals: 18
+        });
+
+        signalService.setVerifyResult(true);
+        address bridgedTokenAddr = bridge.deployCounterpartToken(tokenInit, 1, new bytes(0));
+        BridgedERC20 bridgedToken = BridgedERC20(bridgedTokenAddr);
+
+        // Test originalToken tracking
+        assertEq(bridgedToken.originalToken(), address(originalToken), "originalToken should be tracked");
+
+        // Test ownership (bridge is the owner)
+        assertEq(bridgedToken.owner(), address(bridge), "Bridge should be the owner");
+
+        // Test that only owner (bridge) can mint
+        vm.expectRevert(); // Should revert with OwnableUnauthorizedAccount
+        bridgedToken.mint(alice, 100);
+
+        // Bridge (owner) should be able to mint
+        vm.prank(address(bridge));
+        bridgedToken.mint(alice, 100);
+        assertEq(bridgedToken.balanceOf(alice), 100, "Alice should have 100 tokens");
+    }
+}

--- a/test/ERC721Bridge/Basic.t.sol
+++ b/test/ERC721Bridge/Basic.t.sol
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BridgedERC721} from "../../src/protocol/BridgedERC721.sol";
+import "forge-std/Test.sol";
+import {ERC721Bridge} from "src/protocol/ERC721Bridge.sol";
+import {IERC721Bridge} from "src/protocol/IERC721Bridge.sol";
+import {ISignalService} from "src/protocol/ISignalService.sol";
+import {MockERC721} from "test/mocks/MockERC721.sol";
+import {MockSignalService} from "test/mocks/MockSignalService.sol";
+
+contract ERC721BridgeTest is Test {
+    ERC721Bridge bridge;
+    MockSignalService signalService;
+    MockERC721 token;
+    address trustedPublisher = address(0x123);
+    address counterpart = address(0x456);
+    address alice = address(0xA11CE);
+    address bob = address(0xB0B);
+    uint256 tokenId = 1;
+
+    function setUp() public {
+        signalService = new MockSignalService();
+        bridge = new ERC721Bridge(address(signalService), trustedPublisher, counterpart);
+        token = new MockERC721("Test NFT", "TNFT");
+        token.mint(alice, tokenId);
+        vm.prank(alice);
+        token.approve(address(bridge), tokenId);
+    }
+
+    function testInitializeToken() public {
+        vm.prank(alice);
+        bytes32 id = bridge.initializeToken(address(token));
+
+        assertTrue(bridge.isTokenInitialized(address(token)));
+        assertEq(signalService.lastSignalId(), id);
+    }
+
+    function testCannotInitializeTokenTwice() public {
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.expectRevert("Token already initialized");
+        vm.prank(bob);
+        bridge.initializeToken(address(token));
+    }
+
+    function testDeployCounterpartToken() public {
+        // First initialize on source chain
+        vm.prank(alice);
+        bytes32 id = bridge.initializeToken(address(token));
+
+        // Prepare initialization data for destination chain
+        IERC721Bridge.TokenInitialization memory tokenInit =
+            IERC721Bridge.TokenInitialization({originalToken: address(token), name: "Test NFT", symbol: "TNFT"});
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        // Prove initialization and deploy bridged token
+        address deployedToken = bridge.deployCounterpartToken(tokenInit, height, proof);
+
+        assertTrue(bridge.isInitializationProven(id));
+        assertEq(bridge.getDeployedToken(address(token)), deployedToken);
+
+        // Check that the deployed token has correct metadata
+        BridgedERC721 bridgedToken = BridgedERC721(deployedToken);
+        assertEq(bridgedToken.name(), "Test NFT");
+        assertEq(bridgedToken.symbol(), "TNFT");
+        assertEq(bridgedToken.owner(), address(bridge));
+        assertEq(bridgedToken.originalToken(), address(token));
+    }
+
+    function testCannotProveInitializationTwice() public {
+        // First initialize
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        IERC721Bridge.TokenInitialization memory tokenInit =
+            IERC721Bridge.TokenInitialization({originalToken: address(token), name: "Test NFT", symbol: "TNFT"});
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.deployCounterpartToken(tokenInit, height, proof);
+
+        vm.expectRevert(IERC721Bridge.InitializationAlreadyProven.selector);
+        bridge.deployCounterpartToken(tokenInit, height, proof);
+    }
+
+    function testDeposit() public {
+        // Initialize token first
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, address(0));
+        assertEq(token.ownerOf(tokenId), address(bridge));
+    }
+
+    function testCannotDepositUninitializedToken() public {
+        vm.expectRevert(IERC721Bridge.TokenNotInitialized.selector);
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, address(0));
+    }
+
+    function testClaimDeposit() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bytes32 id = bridge.deposit(bob, address(token), tokenId, address(0));
+
+        IERC721Bridge.ERC721Deposit memory deposit = IERC721Bridge.ERC721Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            tokenURI: "https://example.com/metadata/1",
+            canceler: address(0)
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.claimDeposit(deposit, height, proof);
+
+        assertTrue(bridge.processed(id));
+        assertEq(token.ownerOf(tokenId), bob);
+    }
+
+    function testCancelDeposit() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        address canceler = makeAddr("canceler");
+        vm.prank(alice);
+        bytes32 id = bridge.deposit(bob, address(token), tokenId, canceler);
+
+        IERC721Bridge.ERC721Deposit memory deposit = IERC721Bridge.ERC721Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            tokenURI: "https://example.com/metadata/1",
+            canceler: canceler
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        vm.prank(canceler);
+        bridge.cancelDeposit(deposit, alice, height, proof);
+
+        assertTrue(bridge.processed(id));
+        assertEq(token.ownerOf(tokenId), alice);
+    }
+
+    function testCannotCancelIfNotCanceler() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        address canceler = makeAddr("canceler");
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, canceler);
+
+        IERC721Bridge.ERC721Deposit memory deposit = IERC721Bridge.ERC721Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            tokenURI: "https://example.com/metadata/1",
+            canceler: canceler
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        vm.expectRevert(IERC721Bridge.OnlyCanceler.selector);
+        vm.prank(address(0xBAD));
+        bridge.cancelDeposit(deposit, alice, height, proof);
+    }
+
+    function testCannotClaimAlreadyClaimed() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, address(0));
+
+        IERC721Bridge.ERC721Deposit memory deposit = IERC721Bridge.ERC721Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            tokenURI: "https://example.com/metadata/1",
+            canceler: address(0)
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.claimDeposit(deposit, height, proof);
+
+        vm.expectRevert(IERC721Bridge.AlreadyClaimed.selector);
+        bridge.claimDeposit(deposit, height, proof);
+    }
+
+    function testCannotCancelAlreadyClaimed() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        address canceler = makeAddr("canceler");
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, canceler);
+
+        IERC721Bridge.ERC721Deposit memory deposit = IERC721Bridge.ERC721Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            tokenURI: "https://example.com/metadata/1",
+            canceler: canceler
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        bridge.claimDeposit(deposit, height, proof);
+
+        vm.expectRevert(IERC721Bridge.AlreadyClaimed.selector);
+        vm.prank(canceler);
+        bridge.cancelDeposit(deposit, alice, height, proof);
+    }
+
+    function testCannotCancelIfNoCanceler() public {
+        // Initialize token
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        vm.prank(alice);
+        bridge.deposit(bob, address(token), tokenId, address(0));
+
+        IERC721Bridge.ERC721Deposit memory deposit = IERC721Bridge.ERC721Deposit({
+            nonce: 0,
+            from: alice,
+            to: bob,
+            localToken: address(token),
+            tokenId: tokenId,
+            tokenURI: "https://example.com/metadata/1",
+            canceler: address(0)
+        });
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        vm.expectRevert(IERC721Bridge.OnlyCanceler.selector);
+        vm.prank(makeAddr("random"));
+        bridge.cancelDeposit(deposit, alice, height, proof);
+    }
+
+    function testBridgedTokenDeposit() public {
+        // Create two separate bridge instances to simulate different chains
+        ERC721Bridge bridge2 = new ERC721Bridge(address(signalService), trustedPublisher, counterpart);
+
+        // Initialize token on chain 1
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        // Prove initialization on chain 2 (simulating it came from chain 1)
+        IERC721Bridge.TokenInitialization memory tokenInit =
+            IERC721Bridge.TokenInitialization({originalToken: address(token), name: "Test NFT", symbol: "TNFT"});
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        address bridgedToken = bridge2.deployCounterpartToken(tokenInit, height, proof);
+
+        // Simulate bridging: deposit on chain 1, claim on chain 2
+        vm.prank(alice);
+        bytes32 depositId = bridge.deposit(alice, address(token), tokenId, address(0));
+
+        // For the claim, simulate that this deposit came from chain 1
+        IERC721Bridge.ERC721Deposit memory deposit = IERC721Bridge.ERC721Deposit({
+            nonce: 0,
+            from: alice,
+            to: alice,
+            localToken: address(token),
+            tokenId: tokenId,
+            tokenURI: "https://example.com/metadata/1",
+            canceler: address(0)
+        });
+
+        // Claim on chain 2 (mints bridged token)
+        bridge2.claimDeposit(deposit, height, proof);
+
+        // Now alice has bridged token on chain 2
+        assertEq(BridgedERC721(bridgedToken).ownerOf(tokenId), alice);
+
+        // Alice deposits bridged token back to chain 1
+        vm.prank(alice);
+        BridgedERC721(bridgedToken).approve(address(bridge2), tokenId);
+
+        vm.prank(alice);
+        bridge2.deposit(bob, bridgedToken, tokenId, address(0));
+
+        // Bridged token should be burned (no longer exists)
+        vm.expectRevert();
+        BridgedERC721(bridgedToken).ownerOf(tokenId);
+    }
+
+    function testMetadataPropagation() public {
+        // Create two separate bridge instances to simulate different chains
+        ERC721Bridge bridge2 = new ERC721Bridge(address(signalService), trustedPublisher, counterpart);
+
+        // Initialize token on chain 1
+        vm.prank(alice);
+        bridge.initializeToken(address(token));
+
+        // Prove initialization on chain 2 (simulating it came from chain 1)
+        IERC721Bridge.TokenInitialization memory tokenInit =
+            IERC721Bridge.TokenInitialization({originalToken: address(token), name: "Test NFT", symbol: "TNFT"});
+
+        bytes memory proof = "mock_proof";
+        uint256 height = 1;
+        signalService.setVerifyResult(true);
+
+        address bridgedToken = bridge2.deployCounterpartToken(tokenInit, height, proof);
+
+        // Simulate bridging: deposit on chain 1, claim on chain 2
+        vm.prank(alice);
+        bridge.deposit(alice, address(token), tokenId, address(0));
+
+        // For the claim, simulate that this deposit came from chain 1
+        IERC721Bridge.ERC721Deposit memory deposit = IERC721Bridge.ERC721Deposit({
+            nonce: 0,
+            from: alice,
+            to: alice,
+            localToken: address(token),
+            tokenId: tokenId,
+            tokenURI: "https://example.com/metadata/1",
+            canceler: address(0)
+        });
+
+        // Claim on chain 2 (mints bridged token with metadata)
+        bridge2.claimDeposit(deposit, height, proof);
+
+        // Verify that the bridged token has the correct metadata
+        BridgedERC721 bridgedNFT = BridgedERC721(bridgedToken);
+        assertEq(bridgedNFT.ownerOf(tokenId), alice);
+        assertEq(bridgedNFT.tokenURI(tokenId), "https://example.com/metadata/1");
+
+        // Verify collection metadata is also correct
+        assertEq(bridgedNFT.name(), "Test NFT");
+        assertEq(bridgedNFT.symbol(), "TNFT");
+    }
+}

--- a/test/ProverManager/CurrencyScenario.t.sol
+++ b/test/ProverManager/CurrencyScenario.t.sol
@@ -38,7 +38,7 @@ abstract contract ERC20Currency is InitialState {
     MockERC20 public token;
 
     function setUp() public virtual override {
-        token = new MockERC20();
+        token = new MockERC20("MockERC20", "MCK");
         // do not call super.setUp() because it will be called by the Test contract
     }
 

--- a/test/mocks/MockBrokenERC20.sol
+++ b/test/mocks/MockBrokenERC20.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title MockBrokenERC20
+/// @notice A mock ERC20 token that doesn't implement metadata functions properly
+/// @dev Used to test the try-catch fallbacks in the bridge
+contract MockBrokenERC20 is ERC20 {
+    constructor() ERC20("", "") {
+        _mint(msg.sender, 1000000 * 10 ** 18);
+    }
+
+    // Override metadata functions to revert, simulating a broken token
+    function name() public pure override returns (string memory) {
+        revert("Name not supported");
+    }
+
+    function symbol() public pure override returns (string memory) {
+        revert("Symbol not supported");
+    }
+
+    function decimals() public pure override returns (uint8) {
+        revert("Decimals not supported");
+    }
+}

--- a/test/mocks/MockERC1155.sol
+++ b/test/mocks/MockERC1155.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IMintableERC1155} from "../../src/protocol/IMintable.sol";
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+contract MockERC1155 is ERC1155, IMintableERC1155 {
+    constructor() ERC1155("https://example.com/metadata/{id}.json") {}
+
+    function mint(address to, uint256 id, uint256 amount, bytes memory data) external {
+        _mint(to, id, amount, data);
+    }
+
+    function burn(uint256 id, uint256 amount) external {
+        _burn(msg.sender, id, amount);
+    }
+
+    function uri(uint256 tokenId) public view virtual override returns (string memory) {
+        return string(abi.encodePacked("https://example.com/metadata/", _toString(tokenId), ".json"));
+    }
+
+    function _toString(uint256 value) internal pure returns (string memory) {
+        if (value == 0) {
+            return "0";
+        }
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IMintableERC20} from "../../src/protocol/IMintable.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-/// @title MockERC20
-/// @notice A simple mock implementation of ERC20 for testing purposes
-contract MockERC20 is ERC20 {
-    constructor() ERC20("MockToken", "MOCK") {}
+contract MockERC20 is ERC20, IMintableERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
 
-    function mint(address account, uint256 amount) external {
-        _mint(account, amount);
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
     }
 }

--- a/test/mocks/MockERC721.sol
+++ b/test/mocks/MockERC721.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {IMintableERC721} from "../../src/protocol/IMintable.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract MockERC721 is ERC721, IMintableERC721 {
+    constructor(string memory name, string memory symbol) ERC721(name, symbol) {}
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+
+    function burn(uint256 tokenId) external {
+        require(ownerOf(tokenId) == msg.sender, "Not owner");
+        _burn(tokenId);
+    }
+
+    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+        require(ownerOf(tokenId) != address(0), "ERC721: invalid token ID");
+        return string(abi.encodePacked("https://example.com/metadata/", _toString(tokenId)));
+    }
+
+    function _toString(uint256 value) internal pure returns (string memory) {
+        if (value == 0) {
+            return "0";
+        }
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}

--- a/test/mocks/MockMaliciousERC20.sol
+++ b/test/mocks/MockMaliciousERC20.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title MockMaliciousERC20
+/// @notice A malicious ERC20 token that spoofs the bridge() function
+/// @dev Used to test that the bridge properly rejects spoofed bridged tokens
+contract MockMaliciousERC20 is ERC20 {
+    address private _fakeBridge;
+
+    constructor(address fakeBridge) ERC20("Malicious Token", "EVIL") {
+        _fakeBridge = fakeBridge;
+        _mint(msg.sender, 1000000 * 10 ** 18);
+    }
+
+    /// @dev Spoofs the bridge() function to return the provided address
+    function bridge() external view returns (address) {
+        return _fakeBridge;
+    }
+
+    /// @dev Fake originalToken function to make it look like a bridged token
+    function originalToken() external pure returns (address) {
+        return address(0x1); // Fake original token
+    }
+}

--- a/test/mocks/MockSignalService.sol
+++ b/test/mocks/MockSignalService.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ISignalService} from "src/protocol/ISignalService.sol";
+
+contract MockSignalService is ISignalService {
+    bool verifyResult;
+    bytes32 public lastSignalId;
+
+    function setVerifyResult(bool _result) external {
+        verifyResult = _result;
+    }
+
+    function verifySignal(uint256 _height, address _publisher, address _sender, bytes32 _signal, bytes memory _proof)
+        external
+        view
+    {
+        require(verifyResult, "Mock verify failed");
+    }
+
+    function sendSignal(bytes32 _signal) external returns (bytes32 slot) {
+        lastSignalId = _signal;
+        slot = keccak256(abi.encodePacked(_signal));
+    }
+
+    function isSignalStored(bytes32 _signal, address _sender) external pure returns (bool) {
+        return true;
+    }
+}


### PR DESCRIPTION
This PR introduces bridging support for ERC20, ERC1155, and ERC721 tokens, extending the existing ETH bridge functionality in the minimal rollup protocol.

The new bridges follow the same structure, flows, and systems as the ETHBridge contract, ensuring consistency and ease of maintenance. This includes deposit creation, claiming via storage proofs, and cancellation mechanisms, all integrated with the SignalService for cross-chain verification.

Closes issue https://github.com/OpenZeppelin/minimal-rollup/issues/90