### PR TITLE
Add some zero checks for eth bridge and relayer 

### DIFF
--- a/src/protocol/ETHBridge.sol
+++ b/src/protocol/ETHBridge.sol
@@ -51,6 +51,7 @@ contract ETHBridge is IETHBridge, ReentrancyGuardTransient {
         payable
         returns (bytes32 id)
     {
+        require(to != address(0), ZeroReceiver());
         ETHDeposit memory ethDeposit =
             ETHDeposit(_globalDepositNonce, msg.sender, to, msg.value, data, context, canceler);
         id = _generateId(ethDeposit);

--- a/src/protocol/IETHBridge.sol
+++ b/src/protocol/IETHBridge.sol
@@ -48,6 +48,9 @@ interface IETHBridge {
     /// @dev Only canceler can cancel a deposit.
     error OnlyCanceler();
 
+    /// @dev Zero receiver
+    error ZeroReceiver();
+
     /// @dev Whether the deposit identified by `id` has been claimed or cancelled.
     /// @param id The deposit id
     function processed(bytes32 id) external view returns (bool);

--- a/src/protocol/IMessageRelayer.sol
+++ b/src/protocol/IMessageRelayer.sol
@@ -22,6 +22,9 @@ interface IMessageRelayer {
     /// @dev Tip transfer failed
     error TipTransferFailed();
 
+    /// @dev No Tip Recipient specified
+    error NoTipRecipient();
+
     /// @notice Executes the claimDeposit function on the ETHBridge.
     /// @dev Implements any intermediary step to claim the deposit (i.e. stores tipRecipient address)
     /// @param ethDeposit The deposit to claim

--- a/src/protocol/taiko_alethia/MessageRelayer.sol
+++ b/src/protocol/taiko_alethia/MessageRelayer.sol
@@ -88,6 +88,7 @@ contract MessageRelayer is ReentrancyGuardTransient, IMessageRelayer {
         // If none specified use the one in temporary storage
         if (userSelectedTipRecipient == address(0)) {
             tipRecipient = TIP_RECIPIENT_SLOT.asAddress().tload();
+            require(tipRecipient != address(0), NoTipRecipient());
         }
 
         uint256 valueToSend = msg.value - tip;


### PR DESCRIPTION
- Deposit to should never be zero 
- Added a zero check to message relayer. If both relayer and user selected tip recipient is zero, then something went wrong (most likely relayer didn't call relay message first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added input validation to prevent deposits to the zero address, improving security and error handling.
  * Introduced clearer error messages for invalid receiver and tip recipient addresses.

* **Bug Fixes**
  * Enhanced checks to ensure tip recipient addresses are valid and not zero during message relaying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->